### PR TITLE
Remove version field from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   divitracker:
     image: ghcr.io/${GITHUB_REPOSITORY:-divitracker}:${IMAGE_TAG:-latest}


### PR DESCRIPTION
The 'version' field was removed from docker-compose.yml, likely to improve compatibility with newer Docker Compose versions where the field is optional or deprecated.