### PR TITLE
Update Python base image and dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM python:3.12-slim AS builder
+FROM python:3.13-slim AS builder
 
 WORKDIR /app
 
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir gunicorn
 
 # Production stage
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Flask==3.0.0
+Flask==3.1.2
 Flask-SQLAlchemy==3.1.1
-Flask-Migrate==4.0.5
-pytest==7.4.3
-pytest-cov==4.1.0
+Flask-Migrate==4.1.0
+pytest==9.0.2
+pytest-cov==7.0.0


### PR DESCRIPTION
This pull request updates the Python version used in the Docker build and production environments from 3.12 to 3.13. This ensures the application runs on the latest Python version, which may provide performance improvements, new features, and security updates.

- Docker environment updates:
  * Updated the base image in both the build and production stages of the `Dockerfile` from `python:3.12-slim` to `python:3.13-slim`. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L22-R22)