### PR TITLE
Add cumulative line graph to dividend chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Flask application for tracking dividend income from your investments. Calculat
 - **Dividend Tracking**: Record dividends with monthly, quarterly, semi-annual, or yearly frequency
 - **Yield Calculation**: Automatic computation of annualized dividend yields
 - **Yield Breakdown Page**: Detailed, printable computation breakdown for yield calculations
-- **Dividend Graph**: Visual bar chart representation of dividends with filters by year and investment
+- **Dividend Graph**: Visual bar chart representation of dividends with cumulative line graph, filters by year and investment
 - **Portfolio Dashboard**: Overview of currently invested, annual dividends, and overall yield with year filtering
 - **Pagination**: Configurable items per page for dashboard and dividend history views
 - **Real-time Preview**: See yield calculations before recording dividends
@@ -179,7 +179,8 @@ The dashboard displays:
 ### Dividend Graph
 
 Access the graph page via the "📈 Graph" link in the navigation to view:
-- Bar chart visualization of dividend income
+- Bar chart visualization of dividend income by month
+- Cumulative line graph showing total earnings growth over time (toggle on/off)
 - Filter by year to see monthly breakdown or view all years
 - Filter by specific investment
 - Summary statistics: total, average, and highest dividend amounts

--- a/static/style.css
+++ b/static/style.css
@@ -1435,6 +1435,23 @@ main {
     cursor: pointer;
 }
 
+/* Checkbox label in filters */
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    font-size: 0.875rem;
+    color: var(--text-color);
+}
+
+.checkbox-label input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+    cursor: pointer;
+    accent-color: var(--primary-color);
+}
+
 @media (max-width: 640px) {
     .graph-filters {
         flex-direction: column;

--- a/templates/dividend_graph.html
+++ b/templates/dividend_graph.html
@@ -28,6 +28,12 @@
                 {% endfor %}
             </select>
         </div>
+        <div class="filter-group">
+            <label class="checkbox-label">
+                <input type="checkbox" id="show-cumulative" onchange="toggleCumulative()" checked>
+                Show Cumulative Line
+            </label>
+        </div>
     </div>
 
     <script>
@@ -115,52 +121,124 @@
     const labels = chartData.map(d => d.label);
     const values = chartData.map(d => d.value);
     
+    // Calculate cumulative values
+    let cumulative = 0;
+    const cumulativeValues = values.map(v => {
+        cumulative += v;
+        return cumulative;
+    });
+    
     const ctx = document.getElementById('dividendChart').getContext('2d');
     
-    // Calculate gradient
+    // Calculate gradient for bars
     const gradient = ctx.createLinearGradient(0, 0, 0, 400);
     gradient.addColorStop(0, 'rgba(37, 99, 235, 0.8)');
     gradient.addColorStop(1, 'rgba(37, 99, 235, 0.1)');
     
-    new Chart(ctx, {
+    const currencySymbol = '{{ settings.currency.symbol if settings else "₱" }}';
+    
+    const dividendChart = new Chart(ctx, {
         type: 'bar',
         data: {
             labels: labels,
-            datasets: [{
-                label: 'Dividend Amount',
-                data: values,
-                backgroundColor: gradient,
-                borderColor: 'rgba(37, 99, 235, 1)',
-                borderWidth: 1,
-                borderRadius: 4,
-            }]
+            datasets: [
+                {
+                    label: 'Dividend Amount',
+                    data: values,
+                    backgroundColor: gradient,
+                    borderColor: 'rgba(37, 99, 235, 1)',
+                    borderWidth: 1,
+                    borderRadius: 4,
+                    order: 2,
+                    yAxisID: 'y',
+                },
+                {
+                    label: 'Cumulative Total',
+                    data: cumulativeValues,
+                    type: 'line',
+                    borderColor: 'rgba(22, 163, 74, 1)',
+                    backgroundColor: 'rgba(22, 163, 74, 0.1)',
+                    borderWidth: 2,
+                    pointBackgroundColor: 'rgba(22, 163, 74, 1)',
+                    pointBorderColor: '#fff',
+                    pointBorderWidth: 2,
+                    pointRadius: 4,
+                    pointHoverRadius: 6,
+                    fill: true,
+                    tension: 0.3,
+                    order: 1,
+                    yAxisID: 'y1',
+                }
+            ]
         },
         options: {
             responsive: true,
             maintainAspectRatio: false,
+            interaction: {
+                mode: 'index',
+                intersect: false,
+            },
             plugins: {
                 legend: {
-                    display: false
+                    display: true,
+                    position: 'top',
+                    labels: {
+                        usePointStyle: true,
+                        padding: 20,
+                    }
                 },
                 tooltip: {
                     callbacks: {
                         label: function(context) {
-                            return '{{ settings.currency.symbol if settings else "₱" }}' + context.raw.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
+                            return context.dataset.label + ': ' + currencySymbol + context.raw.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
                         }
                     }
                 }
             },
             scales: {
                 y: {
+                    type: 'linear',
+                    display: true,
+                    position: 'left',
                     beginAtZero: true,
+                    title: {
+                        display: true,
+                        text: 'Dividend Amount'
+                    },
                     ticks: {
                         callback: function(value) {
-                            return '{{ settings.currency.symbol if settings else "₱" }}' + value.toLocaleString();
+                            return currencySymbol + value.toLocaleString();
                         }
                     }
+                },
+                y1: {
+                    type: 'linear',
+                    display: true,
+                    position: 'right',
+                    beginAtZero: true,
+                    title: {
+                        display: true,
+                        text: 'Cumulative Total'
+                    },
+                    ticks: {
+                        callback: function(value) {
+                            return currencySymbol + value.toLocaleString();
+                        }
+                    },
+                    grid: {
+                        drawOnChartArea: false,
+                    },
                 }
             }
         }
     });
+    
+    // Toggle cumulative line visibility
+    function toggleCumulative() {
+        const showCumulative = document.getElementById('show-cumulative').checked;
+        dividendChart.data.datasets[1].hidden = !showCumulative;
+        dividendChart.options.scales.y1.display = showCumulative;
+        dividendChart.update();
+    }
 </script>
 {% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -85,6 +85,20 @@ class TestDividendGraphRoutes:
         assert response.status_code == 200
         assert b"chart_data" in response.data or b"chartData" in response.data
 
+    def test_dividend_graph_has_cumulative_toggle(self, client):
+        """Test that dividend graph has cumulative line toggle."""
+        response = client.get("/dividend-graph")
+        assert response.status_code == 200
+        assert b"Show Cumulative Line" in response.data
+        assert b"showCumulative" in response.data
+
+    def test_dividend_graph_cumulative_chart_elements(self, client):
+        """Test that dividend graph has cumulative chart configuration."""
+        response = client.get("/dividend-graph")
+        assert response.status_code == 200
+        assert b"Cumulative Total" in response.data
+        assert b"toggleCumulative" in response.data
+
 
 class TestPagination:
     """Tests for pagination functionality."""


### PR DESCRIPTION
This pull request enhances the dividend graph feature by adding a cumulative line graph to visualize total earnings growth over time, along with related UI and testing improvements. The main changes include updates to the graph's display, user controls for toggling the cumulative line, and new tests to verify these features.

**Dividend Graph Enhancements:**

* Added a cumulative line graph to the dividend graph page, allowing users to visualize the growth of total dividend earnings over time alongside the existing monthly bar chart.
* Updated the graph filters UI to include a checkbox for toggling the visibility of the cumulative line, with corresponding CSS for consistent styling. [[1]](diffhunk://#diff-a3827e270957d77df3550595ca1dec03b108a5d3c95f27a26c6406536332c688R31-R36) [[2]](diffhunk://#diff-9a60ff1ad658a0c4dec6ea96847009b7f01b3e103107040b4b0705de525d737aR1438-R1454)

**Documentation Updates:**

* Revised the `README.md` to describe the new cumulative line graph feature and clarify the graph's functionality. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L182-R183)

**Testing Improvements:**

* Added new tests to verify the presence of the cumulative line toggle and the correct chart configuration in the dividend graph view.