### PR TITLE
Add dividend details modal to graph view

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -185,26 +185,27 @@ def dividend_graph():
     selected_year = request.args.get("year", type=int)
     selected_investment_id = request.args.get("investment_id", type=int)
 
-    # Build chart data
+    # Build chart data with detailed dividend breakdown
     chart_data = []
 
     if selected_year:
         # Monthly breakdown for a specific year
         months = [
-            "Jan",
-            "Feb",
-            "Mar",
-            "Apr",
+            "January",
+            "February",
+            "March",
+            "April",
             "May",
-            "Jun",
-            "Jul",
-            "Aug",
-            "Sep",
-            "Oct",
-            "Nov",
-            "Dec",
+            "June",
+            "July",
+            "August",
+            "September",
+            "October",
+            "November",
+            "December",
         ]
-        monthly_totals = {i: 0.0 for i in range(1, 13)}
+        monthly_totals: dict[int, float] = {i: 0.0 for i in range(1, 13)}
+        monthly_details: dict[int, list[dict]] = {i: [] for i in range(1, 13)}
 
         for inv in investments:
             if selected_investment_id and inv.id != selected_investment_id:
@@ -212,17 +213,45 @@ def dividend_graph():
             for div in inv.dividends.all():
                 if div.period_year == selected_year and div.period_month:
                     monthly_totals[div.period_month] += div.amount
+                    monthly_details[div.period_month].append(
+                        {
+                            "investment_name": inv.name,
+                            "investment_id": inv.id,
+                            "amount": div.amount,
+                            "frequency": div.frequency,
+                            "date_received": div.date_received.strftime("%Y-%m-%d"),
+                        }
+                    )
 
-        chart_data = [{"label": months[i - 1], "value": monthly_totals[i]} for i in range(1, 13)]
+        chart_data = [
+            {
+                "label": months[i - 1],
+                "value": monthly_totals[i],
+                "details": monthly_details[i],
+            }
+            for i in range(1, 13)
+        ]
     else:
-        # Yearly totals
+        # Yearly totals with details
         for year in sorted(years_with_dividends):
             year_total = 0.0
+            year_details: list[dict] = []
             for inv in investments:
                 if selected_investment_id and inv.id != selected_investment_id:
                     continue
-                year_total += inv.calculate_annual_dividends(year)
-            chart_data.append({"label": str(year), "value": year_total})
+                inv_year_total = inv.calculate_annual_dividends(year)
+                if inv_year_total > 0:
+                    year_total += inv_year_total
+                    year_details.append(
+                        {
+                            "investment_name": inv.name,
+                            "investment_id": inv.id,
+                            "amount": inv_year_total,
+                            "frequency": "Annual Total",
+                            "date_received": str(year),
+                        }
+                    )
+            chart_data.append({"label": str(year), "value": year_total, "details": year_details})
 
     # Get investment list for filter dropdown
     investment_list = [{"id": inv.id, "name": inv.name} for inv in investments]

--- a/static/style.css
+++ b/static/style.css
@@ -1581,3 +1581,91 @@ main {
     left: 0;
     color: var(--primary-color);
 }
+
+/* Modal Styles */
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    padding: 1rem;
+}
+
+.modal-content {
+    background-color: var(--card-bg);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-lg);
+    max-width: 700px;
+    width: 100%;
+    max-height: 80vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.modal-header h3 {
+    margin: 0;
+    font-size: 1.25rem;
+    color: var(--text-color);
+}
+
+.modal-close {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: var(--text-muted);
+    padding: 0;
+    line-height: 1;
+    transition: color 0.2s;
+}
+
+.modal-close:hover {
+    color: var(--danger-color);
+}
+
+.modal-body {
+    padding: 1.5rem;
+    overflow-y: auto;
+}
+
+.modal-body .data-table {
+    margin: 0;
+}
+
+.modal-body .data-table a {
+    color: var(--primary-color);
+    text-decoration: none;
+}
+
+.modal-body .data-table a:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+    .modal-content {
+        max-height: 90vh;
+    }
+    
+    .modal-header {
+        padding: 0.75rem 1rem;
+    }
+    
+    .modal-body {
+        padding: 1rem;
+    }
+}

--- a/templates/dividend_graph.html
+++ b/templates/dividend_graph.html
@@ -106,6 +106,36 @@
     <div class="back-link">
         <a href="{{ url_for('main.index') }}">← Back to Dashboard</a>
     </div>
+
+    <!-- Modal for dividend details -->
+    <div id="dividendModal" class="modal" style="display: none;">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 id="modalTitle">Dividend Details</h3>
+                <button class="modal-close" onclick="closeModal()">&times;</button>
+            </div>
+            <div class="modal-body">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Investment</th>
+                            <th>Amount</th>
+                            <th>Frequency</th>
+                        </tr>
+                    </thead>
+                    <tbody id="modalTableBody">
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <th>Total</th>
+                            <th id="modalTotal"></th>
+                            <th></th>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock content %}
 
@@ -131,6 +161,10 @@
     gradient.addColorStop(1, 'rgba(37, 99, 235, 0.1)');
     
     const currencySymbol = '{{ settings.currency.symbol if settings else "₱" }}';
+    
+    function formatCurrency(value) {
+        return currencySymbol + value.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
+    }
     
     const dividendChart = new Chart(ctx, {
         type: 'bar',
@@ -173,6 +207,15 @@
                 mode: 'index',
                 intersect: false,
             },
+            onClick: function(event, elements) {
+                if (elements.length > 0) {
+                    const index = elements[0].index;
+                    const data = chartData[index];
+                    if (data.details && data.details.length > 0) {
+                        showDividendDetails(data.label, data.details, data.value);
+                    }
+                }
+            },
             plugins: {
                 legend: {
                     display: true,
@@ -186,6 +229,14 @@
                     callbacks: {
                         label: function(context) {
                             return context.dataset.label + ': ' + currencySymbol + context.raw.toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
+                        },
+                        afterBody: function(context) {
+                            const index = context[0].dataIndex;
+                            const data = chartData[index];
+                            if (data.details && data.details.length > 0) {
+                                return '\nClick to view breakdown';
+                            }
+                            return '';
                         }
                     }
                 }
@@ -235,5 +286,45 @@
         dividendChart.options.scales.y1.display = showCumulative;
         dividendChart.update();
     }
+    
+    // Modal functions
+    function showDividendDetails(period, details, total) {
+        const modal = document.getElementById('dividendModal');
+        const modalTitle = document.getElementById('modalTitle');
+        const modalTableBody = document.getElementById('modalTableBody');
+        const modalTotal = document.getElementById('modalTotal');
+        
+        modalTitle.textContent = 'Dividend Details - ' + period;
+        modalTotal.textContent = formatCurrency(total);
+        
+        // Build table rows
+        modalTableBody.innerHTML = details.map(d => `
+            <tr>
+                <td><a href="/investments/${d.investment_id}">${d.investment_name}</a></td>
+                <td>${formatCurrency(d.amount)}</td>
+                <td>${d.frequency}</td>
+            </tr>
+        `).join('');
+        
+        modal.style.display = 'flex';
+    }
+    
+    function closeModal() {
+        document.getElementById('dividendModal').style.display = 'none';
+    }
+    
+    // Close modal when clicking outside
+    document.getElementById('dividendModal').addEventListener('click', function(e) {
+        if (e.target === this) {
+            closeModal();
+        }
+    });
+    
+    // Close modal on escape key
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+            closeModal();
+        }
+    });
 </script>
 {% endblock scripts %}


### PR DESCRIPTION
This pull request enhances the dividend graph feature by adding a detailed breakdown of dividend data and introducing a modal dialog for viewing per-period dividend details. The changes span backend data preparation, frontend interactivity, and new modal styling to provide a richer user experience.

**Dividend Data Enhancements:**

- The backend (`main.py`) now includes a detailed breakdown of dividends by investment for each month or year, making it possible to display granular dividend information in the UI.

**Frontend Interactivity & Modal Integration:**

- A modal dialog is added to `dividend_graph.html` to display detailed dividend information for a selected period, including investment name, amount, and frequency.
- JavaScript is updated to handle chart clicks: clicking a bar in the dividend chart opens the modal with a breakdown of dividends for that period.
- Tooltip callbacks in the chart now hint to users that clicking will show a breakdown.
- Utility functions are added for currency formatting and modal control (open/close, keyboard and click-outside handling). [[1]](diffhunk://#diff-a3827e270957d77df3550595ca1dec03b108a5d3c95f27a26c6406536332c688R165-R168) [[2]](diffhunk://#diff-a3827e270957d77df3550595ca1dec03b108a5d3c95f27a26c6406536332c688R289-R328)

**Styling:**

- New CSS styles are introduced for the modal dialog, ensuring it is visually integrated and responsive on different screen sizes.