### PR TITLE
Potential fix for code scanning alert no. 43: Empty except

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -118,7 +118,9 @@ def get_version() -> str:
             if version:
                 _version_cache = version
                 return _version_cache
-    except Exception:
+    except OSError:
+        # If the VERSION file cannot be read (e.g., missing or permission error),
+        # silently fall back to git-based detection and 'dev' default below.
         pass
 
     # Try to get from git tags (for development)


### PR DESCRIPTION
Potential fix for [https://github.com/phdwight/divitracker/security/code-scanning/43](https://github.com/phdwight/divitracker/security/code-scanning/43)

General fix: avoid empty `except` blocks. Either (a) narrow the exception types and handle them explicitly, (b) add logging or metrics so the failure is observable, or (c) add an explanatory comment if ignoring is genuinely intentional.

Best minimal fix here: keep the existing behavior (attempt VERSION file, and if anything goes wrong, just move on to git detection) but (1) restrict the exception to filesystem-related errors likely in this context, and (2) add a brief comment explaining that failures are intentionally ignored. To avoid adding new imports or changing behavior, we can catch `OSError` (base class for most file/path I/O errors) and keep a no-op body, but document why it’s acceptable.

Concretely, in `app/utils.py`, within `get_version`, change:

```python
    except Exception:
        pass
```

to something like:

```python
    except OSError:
        # If VERSION file cannot be read (e.g., missing or permission error),
        # fall back to git-based detection and 'dev' default below.
        pass
```

This preserves all behavior, removes the overly broad catch, and explains the intentional ignore. No new methods or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
