### PR TITLE
Implement amount masking feature with toggle button and CSS updates

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -18,6 +18,51 @@
 .hidden {
     display: none;
 }
+
+/* Amount masking toggle */
+.mask-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    cursor: pointer;
+}
+.mask-toggle .mask-icon {
+    font-size: 1rem;
+    line-height: 1;
+}
+.nav-mask-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    color: inherit;
+    font: inherit;
+    padding: 0.35rem 0.7rem;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+.nav-mask-toggle:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.5);
+}
+.nav-mask-toggle[aria-pressed="true"] {
+    background-color: rgba(255, 255, 255, 0.15);
+}
+.nav-mask-toggle .mask-icon {
+    font-size: 1rem;
+    line-height: 1;
+}
+body.amounts-masked .maskable {
+    filter: blur(7px);
+    transition: filter 0.15s ease-in-out;
+    user-select: none;
+    cursor: pointer;
+}
+body.amounts-masked .maskable:hover {
+    filter: blur(0);
+}
     --shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
     --shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.1);
     --radius: 8px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,7 +6,7 @@
     <meta name="description" content="DiviTracker - Track and manage your dividend income from investments">
     <meta name="keywords" content="dividends, investments, portfolio, tracker, income">
     <title>{% block title %}DiviTracker{% endblock title %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=mask2">
 </head>
 <body>
     <nav class="navbar">
@@ -18,6 +18,10 @@
                 <a href="{{ url_for('investments.add_investment') }}">Add Investment</a>
                 <a href="{{ url_for('dividends.add_dividend') }}">Add Dividend</a>
                 <a href="{{ url_for('admin.admin_index') }}">⚙️ Settings</a>
+                <button type="button" id="mask-toggle" class="nav-mask-toggle" onclick="toggleAmountsMask()" title="Hide/Show amounts" aria-pressed="false">
+                    <span class="mask-icon">👁️</span>
+                    <span class="mask-label">Hide amounts</span>
+                </button>
             </div>
         </div>
     </nav>
@@ -51,6 +55,33 @@
                 setTimeout(() => alert.remove(), 300);
             });
         }, 5000);
+
+        // Global amount masking toggle
+        (function () {
+            const STORAGE_KEY = 'divitracker.amountsMasked';
+            const btn = document.getElementById('mask-toggle');
+            const labelEl = btn ? btn.querySelector('.mask-label') : null;
+            const iconEl = btn ? btn.querySelector('.mask-icon') : null;
+
+            function applyState(masked) {
+                document.body.classList.toggle('amounts-masked', masked);
+                if (btn) {
+                    btn.setAttribute('aria-pressed', masked ? 'true' : 'false');
+                    if (labelEl) labelEl.textContent = masked ? 'Show amounts' : 'Hide amounts';
+                    if (iconEl) iconEl.textContent = masked ? '🙈' : '👁️';
+                }
+            }
+
+            window.toggleAmountsMask = function () {
+                const next = !document.body.classList.contains('amounts-masked');
+                try { localStorage.setItem(STORAGE_KEY, next ? '1' : '0'); } catch (e) {}
+                applyState(next);
+            };
+
+            let initial = false;
+            try { initial = localStorage.getItem(STORAGE_KEY) === '1'; } catch (e) {}
+            applyState(initial);
+        })();
     </script>
     {% block scripts %}{% endblock scripts %}
 </body>

--- a/templates/dividend_graph.html
+++ b/templates/dividend_graph.html
@@ -48,18 +48,18 @@
     </script>
 
     <div class="graph-container">
-        <div class="chart-wrapper">
+        <div class="chart-wrapper maskable">
             <canvas id="dividendChart"></canvas>
         </div>
         
         <div class="chart-summary">
             <div class="summary-card">
                 <h3>Total Displayed</h3>
-                <p class="summary-value" id="totalValue">{{ format_currency(chart_data | sum(attribute='value')) }}</p>
+                <p class="summary-value maskable" id="totalValue">{{ format_currency(chart_data | sum(attribute='value')) }}</p>
             </div>
             <div class="summary-card">
                 <h3>Highest</h3>
-                <p class="summary-value" id="maxValue">
+                <p class="summary-value maskable" id="maxValue">
                     {% if chart_data %}
                     {{ format_currency(chart_data | map(attribute='value') | max) }}
                     {% else %}
@@ -87,15 +87,15 @@
                     {% set cumulative.total = cumulative.total + item.value %}
                     <tr>
                         <td>{{ item.label }}</td>
-                        <td>{{ format_currency(item.value) }}</td>
-                        <td>{{ format_currency(cumulative.total) }}</td>
+                        <td class="maskable">{{ format_currency(item.value) }}</td>
+                        <td class="maskable">{{ format_currency(cumulative.total) }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>
                 <tfoot>
                     <tr>
                         <th>Total</th>
-                        <th>{{ format_currency(chart_data | sum(attribute='value')) }}</th>
+                        <th class="maskable">{{ format_currency(chart_data | sum(attribute='value')) }}</th>
                         <th></th>
                     </tr>
                 </tfoot>

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,14 +47,14 @@
             <div class="stat-icon">📊</div>
             <div class="stat-content">
                 <h3>Currently Invested</h3>
-                <p class="stat-value">{{ format_currency(total_invested) }}</p>
+                <p class="stat-value maskable">{{ format_currency(total_invested) }}</p>
             </div>
         </div>
         <div class="stat-card">
             <div class="stat-icon">💵</div>
             <div class="stat-content">
                 <h3>Dividends Received ({{ selected_year }})</h3>
-                <p class="stat-value">{{ format_currency(total_annual_dividends) }}</p>
+                <p class="stat-value maskable">{{ format_currency(total_annual_dividends) }}</p>
             </div>
         </div>
         <a href="{{ url_for('main.yield_breakdown', year=selected_year) }}" class="stat-card highlight stat-card-link">
@@ -95,8 +95,8 @@
                             </a>
                         </td>
                         <td>{{ investment.ticker or '-' }}</td>
-                        <td>{{ format_currency(investment.total_invested) }}</td>
-                        <td>{{ format_currency(investment.calculate_annual_dividends(selected_year)) }}</td>
+                        <td class="maskable">{{ format_currency(investment.total_invested) }}</td>
+                        <td class="maskable">{{ format_currency(investment.calculate_annual_dividends(selected_year)) }}</td>
                         <td>
                             <span class="yield-dual">
                                 <span class="yield-badge {% if investment.calculate_dividend_yield(selected_year) >= 5 %}yield-high{% elif investment.calculate_dividend_yield(selected_year) >= 2 %}yield-medium{% else %}yield-low{% endif %}">
@@ -174,3 +174,5 @@
     </div>
 </div>
 {% endblock content %}
+
+{% block scripts %}{% endblock scripts %}


### PR DESCRIPTION
This pull request introduces a global "amount masking" feature, allowing users to toggle the visibility of sensitive monetary values across the app. The implementation includes a toggle button in the navigation bar, persistent state using localStorage, and visual masking of amounts using a blur effect. The change is applied consistently across dashboard, graph, and table views.

**Amount Masking Feature:**

* Added a navigation bar toggle button (`mask-toggle`) that allows users to hide or show all monetary amounts, with state persisted in `localStorage` and accessible via the `toggleAmountsMask()` function. [[1]](diffhunk://#diff-690b81fad8df2a1f1ce37c846641d9247e3472d244f17039d2910a5ed0c98d5eR21-R24) [[2]](diffhunk://#diff-690b81fad8df2a1f1ce37c846641d9247e3472d244f17039d2910a5ed0c98d5eR58-R84)
* Updated CSS (`static/style.css`) to add styles for `.mask-toggle`, `.nav-mask-toggle`, and `.maskable` elements, including a blur effect for masked amounts and hover-to-unmask behavior.

**Template Updates for Masking:**

* Marked all displayed monetary values in the dashboard (`templates/index.html`) and dividend graph (`templates/dividend_graph.html`) with the `maskable` class, so they are affected by the masking toggle. [[1]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L50-R57) [[2]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2L98-R99) [[3]](diffhunk://#diff-a3827e270957d77df3550595ca1dec03b108a5d3c95f27a26c6406536332c688L51-R62) [[4]](diffhunk://#diff-a3827e270957d77df3550595ca1dec03b108a5d3c95f27a26c6406536332c688L90-R98)

**Other:**

* Updated the stylesheet link in `base.html` to include a cache-busting query string.
* Added an empty `{% block scripts %}` to `index.html` for consistency.