### PR TITLE
Redesign UI with dark night theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 /app/routes/__pycache__
 .env
 .env.example
+
+# Design mocks
+DiviTracker Night - Redesign.html

--- a/static/style.css
+++ b/static/style.css
@@ -1,71 +1,70 @@
-/* CSS Variables */
+/* ============================================================
+   DiviTracker — Night theme
+   Design tokens taken from "DiviTracker Night - Redesign"
+   ============================================================ */
+
 :root {
-    --primary-color: #2563eb;
-    --primary-hover: #1d4ed8;
-    --success-color: #16a34a;
-    --success-hover: #15803d;
-    --danger-color: #dc2626;
-    --danger-hover: #b91c1c;
-    --warning-color: #f59e0b;
-    --info-color: #0891b2;
-    --text-color: #1f2937;
-    --text-muted: #6b7280;
-    --bg-color: #f3f4f6;
-    --card-bg: #ffffff;
-    --border-color: #e5e7eb;
+    color-scheme: dark;
 
-/* Utility classes */
-.hidden {
-    display: none;
-}
+    /* Palette */
+    --bg-color: #1c1928;
+    --accent: #8b5cf6;
+    --accent-deep: #6d28d9;
+    --accent-soft: #a78bfa;
+    --accent-text: #c9b3f9;
+    --link-color: #b79df5;
+    --link-hover: #cdbaf8;
 
-/* Amount masking toggle */
-.mask-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    cursor: pointer;
-}
-.mask-toggle .mask-icon {
-    font-size: 1rem;
-    line-height: 1;
-}
-.nav-mask-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    background: transparent;
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    color: inherit;
-    font: inherit;
-    padding: 0.35rem 0.7rem;
-    border-radius: 999px;
-    cursor: pointer;
-    transition: background-color 0.15s ease, border-color 0.15s ease;
-}
-.nav-mask-toggle:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-    border-color: rgba(255, 255, 255, 0.5);
-}
-.nav-mask-toggle[aria-pressed="true"] {
-    background-color: rgba(255, 255, 255, 0.15);
-}
-.nav-mask-toggle .mask-icon {
-    font-size: 1rem;
-    line-height: 1;
-}
-body.amounts-masked .maskable {
-    filter: blur(7px);
-    transition: filter 0.15s ease-in-out;
-    user-select: none;
-    cursor: pointer;
-}
-body.amounts-masked .maskable:hover {
-    filter: blur(0);
-}
-    --shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    --shadow-lg: 0 4px 6px rgba(0, 0, 0, 0.1);
-    --radius: 8px;
+    --text-color: #eae7f2;
+    --text-bright: #f4f2fa;
+    --text-soft: #b6b1c6;
+    --text-muted: #948fa8;
+    --text-faint: #7d7891;
+
+    /* Surfaces */
+    --card-bg: rgba(255, 255, 255, 0.05);
+    --card-border: rgba(255, 255, 255, 0.08);
+    --row-bg: rgba(255, 255, 255, 0.045);
+    --row-border: rgba(255, 255, 255, 0.07);
+    --row-hover-bg: rgba(255, 255, 255, 0.055);
+    --row-hover-border: rgba(139, 92, 246, 0.35);
+    --pill-bg: rgba(255, 255, 255, 0.06);
+    --pill-border: rgba(255, 255, 255, 0.1);
+    --ctrl-bg: rgba(255, 255, 255, 0.045);
+    --ctrl-border: rgba(255, 255, 255, 0.12);
+
+    /* Status */
+    --good: #6fe0a8;
+    --good-bg: rgba(52, 199, 123, 0.14);
+    --good-border: rgba(52, 199, 123, 0.35);
+    --warn: #f2c665;
+    --warn-bg: rgba(245, 185, 66, 0.13);
+    --warn-border: rgba(245, 185, 66, 0.35);
+    --bad: #f28b8b;
+    --bad-bg: rgba(244, 94, 94, 0.13);
+    --bad-border: rgba(244, 94, 94, 0.35);
+
+    /* Legacy aliases (kept so nothing referencing them breaks) */
+    --primary-color: #8b5cf6;
+    --primary-hover: #7c3aed;
+    --success-color: #34c77b;
+    --success-hover: #2bb56d;
+    --danger-color: #f45e5e;
+    --danger-hover: #e04c4c;
+    --warning-color: #f5b942;
+    --info-color: #7dd0e0;
+    --border-color: rgba(255, 255, 255, 0.1);
+
+    /* Effects */
+    --glow-shadow: 0 8px 24px rgba(109, 40, 217, 0.4);
+    --glow-shadow-lg: 0 16px 44px rgba(109, 40, 217, 0.4);
+    --shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+    --shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.35);
+    --radius: 12px;
+    --radius-card: 20px;
+    --radius-row: 18px;
+
+    --chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='13' height='13' viewBox='0 0 24 24' fill='none' stroke='%23948fa8' stroke-width='2.25' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
 }
 
 /* Reset */
@@ -76,8 +75,10 @@ body.amounts-masked .maskable:hover {
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
-    background-color: var(--bg-color);
+    font-family: 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background:
+        radial-gradient(1100px 480px at 75% -10%, rgba(139, 92, 246, 0.2), transparent 65%),
+        var(--bg-color);
     color: var(--text-color);
     line-height: 1.6;
     min-height: 100vh;
@@ -85,69 +86,176 @@ body {
     flex-direction: column;
 }
 
+a {
+    color: var(--link-color);
+    text-decoration: none;
+}
+
+a:hover {
+    color: var(--link-hover);
+}
+
+::selection {
+    background: rgba(124, 58, 237, 0.4);
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+    accent-color: var(--accent);
+}
+
+:focus-visible {
+    outline: 2px solid rgba(139, 92, 246, 0.7);
+    outline-offset: 2px;
+}
+
+svg {
+    flex-shrink: 0;
+}
+
+/* Utility */
+.hidden {
+    display: none;
+}
+
+.text-muted {
+    color: var(--text-muted);
+}
+
 /* Container */
 .container {
-    max-width: 1200px;
+    max-width: 1240px;
     margin: 0 auto;
-    padding: 0 1rem;
+    padding: 0 24px;
     width: 100%;
 }
 
-/* Navigation */
+/* ============================================================
+   Header / navigation
+   ============================================================ */
 .navbar {
-    background-color: var(--card-bg);
-    box-shadow: var(--shadow);
-    padding: 1rem 0;
-    position: sticky;
-    top: 0;
-    z-index: 100;
+    padding: 22px 0 0;
 }
 
 .navbar .container {
     display: flex;
-    justify-content: space-between;
+    flex-wrap: wrap;
     align-items: center;
+    gap: 14px 24px;
 }
 
 .logo {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--primary-color);
-    text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 19px;
+    font-weight: 600;
+    color: var(--text-bright);
+    letter-spacing: -0.01em;
+}
+
+.logo:hover {
+    color: var(--text-bright);
+}
+
+.logo-mark {
+    width: 30px;
+    height: 30px;
+    border-radius: 9px;
+    background: linear-gradient(135deg, var(--accent), var(--accent-deep));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 18px rgba(124, 58, 237, 0.45);
 }
 
 .nav-links {
     display: flex;
-    gap: 1.5rem;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    background: var(--pill-bg);
+    border: 1px solid var(--pill-border);
+    border-radius: 999px;
+    padding: 5px;
+    font-size: 14px;
+    font-weight: 500;
 }
 
 .nav-links a {
-    color: var(--text-color);
-    text-decoration: none;
-    font-weight: 500;
-    transition: color 0.2s;
+    padding: 8px 16px;
+    border-radius: 999px;
+    color: var(--text-soft);
+    transition: color 0.15s ease, background-color 0.15s ease;
 }
 
 .nav-links a:hover {
-    color: var(--primary-color);
+    color: var(--text-color);
+    background: rgba(255, 255, 255, 0.06);
 }
 
-/* Main Content */
+.nav-links a.active {
+    background: rgba(139, 92, 246, 0.28);
+    color: #e6dcfc;
+}
+
+.nav-mask-toggle {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--ctrl-bg);
+    border: 1px solid var(--pill-border);
+    color: #cfcadd;
+    font-family: inherit;
+    font-size: 13.5px;
+    font-weight: 500;
+    padding: 9px 16px;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.nav-mask-toggle:hover {
+    background: rgba(255, 255, 255, 0.09);
+}
+
+.nav-mask-toggle[aria-pressed="true"] {
+    background: rgba(139, 92, 246, 0.18);
+    border-color: rgba(139, 92, 246, 0.4);
+}
+
+/* Amount masking */
+body.amounts-masked .maskable {
+    filter: blur(7px);
+    transition: filter 0.15s ease-in-out;
+    user-select: none;
+    cursor: pointer;
+}
+
+body.amounts-masked .maskable:hover {
+    filter: blur(0);
+}
+
+/* Main content */
 main {
     flex: 1;
-    padding: 2rem 0;
+    padding: 44px 0 64px;
 }
 
-/* Alerts */
+/* ============================================================
+   Alerts
+   ============================================================ */
 .alert {
-    padding: 1rem 1.5rem;
-    border-radius: var(--radius);
+    padding: 14px 20px;
+    border-radius: 14px;
     margin-bottom: 1rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
     animation: slideIn 0.3s ease;
     transition: opacity 0.3s ease;
+    font-size: 14.5px;
 }
 
 @keyframes slideIn {
@@ -162,15 +270,15 @@ main {
 }
 
 .alert-success {
-    background-color: #dcfce7;
-    color: #166534;
-    border: 1px solid #86efac;
+    background-color: var(--good-bg);
+    color: var(--good);
+    border: 1px solid var(--good-border);
 }
 
 .alert-error {
-    background-color: #fee2e2;
-    color: #991b1b;
-    border: 1px solid #fca5a5;
+    background-color: var(--bad-bg);
+    color: var(--bad);
+    border: 1px solid var(--bad-border);
 }
 
 .close-btn {
@@ -179,134 +287,363 @@ main {
     font-size: 1.25rem;
     cursor: pointer;
     opacity: 0.6;
+    color: inherit;
 }
 
 .close-btn:hover {
     opacity: 1;
 }
 
-/* Dashboard */
-.dashboard h1 {
-    margin-bottom: 1.5rem;
-    font-size: 2rem;
+/* ============================================================
+   Page titles
+   ============================================================ */
+.dashboard h1,
+.page-header h1,
+.form-page h1,
+.yield-title h1,
+.investment-detail h1 {
+    font-size: clamp(30px, 4.6vw, 42px);
+    font-weight: 300;
+    letter-spacing: -0.02em;
+    line-height: 1.05;
+    color: var(--text-color);
 }
 
+.dashboard h1 span,
+.page-header h1 span,
+.form-page h1 span,
+.yield-title h1 span {
+    font-weight: 600;
+    color: var(--accent-text);
+}
+
+.page-subtitle,
+.page-header .text-muted {
+    margin-top: 10px;
+    font-size: 14.5px;
+    color: var(--text-muted);
+    font-weight: 400;
+}
+
+.page-header {
+    margin-bottom: 34px;
+}
+
+/* Dashboard header row */
 .dashboard-header {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1.5rem;
     flex-wrap: wrap;
-    gap: 1rem;
-}
-
-.dashboard-header h1 {
-    margin-bottom: 0;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 18px 32px;
+    margin-bottom: 34px;
 }
 
 .dashboard-filters {
     display: flex;
     align-items: center;
-    gap: 1.5rem;
+    gap: 12px 20px;
     flex-wrap: wrap;
 }
 
-.filter-checkbox {
+.filter-checkbox label,
+.checkbox-label {
     display: flex;
     align-items: center;
+    gap: 9px;
+    cursor: pointer;
+    font-size: 14px;
+    color: var(--text-soft);
 }
 
-.filter-checkbox label {
+.filter-checkbox input[type="checkbox"],
+.checkbox-label input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+}
+
+/* Year pill selector */
+.year-selector {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    cursor: pointer;
-    font-size: 0.875rem;
+    gap: 4px;
+    background: var(--ctrl-bg);
+    border: 1px solid var(--pill-border);
+    border-radius: 999px;
+    padding: 5px 8px 5px 18px;
+    width: fit-content;
+    font-size: 14px;
+}
+
+.year-selector label {
     color: var(--text-muted);
+    font-weight: 400;
 }
 
-.filter-checkbox input[type="checkbox"] {
-    width: 1rem;
-    height: 1rem;
+.year-selector select {
+    border: none;
+    background: transparent;
+    color: var(--text-color);
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 600;
+    padding: 4px 26px 4px 8px;
     cursor: pointer;
+    appearance: none;
+    background-image: var(--chevron);
+    background-repeat: no-repeat;
+    background-position: right 8px center;
 }
 
-/* Stats Grid */
+.year-selector select:focus {
+    outline: none;
+}
+
+/* ============================================================
+   Stat cards
+   ============================================================ */
 .stats-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 18px;
+    margin-bottom: 44px;
+}
+
+.detail-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
     margin-bottom: 2rem;
 }
 
 .stat-card {
-    background-color: var(--card-bg);
-    border-radius: var(--radius);
-    padding: 1.5rem;
-    box-shadow: var(--shadow);
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: var(--radius-card);
+    padding: 26px 28px;
+    display: block;
+}
+
+.stat-label,
+.stat-content h3 {
     display: flex;
     align-items: center;
-    gap: 1rem;
-}
-
-.stat-card.highlight {
-    background: linear-gradient(135deg, var(--primary-color), #3b82f6);
-    color: white;
-}
-
-.stat-icon {
-    font-size: 2rem;
-}
-
-.stat-content h3 {
-    font-size: 0.875rem;
-    font-weight: 500;
+    gap: 9px;
+    font-size: 13px;
     color: var(--text-muted);
-    margin-bottom: 0.25rem;
+    font-weight: 500;
+    margin-bottom: 16px;
 }
 
-.stat-card.highlight .stat-content h3 {
-    color: rgba(255, 255, 255, 0.8);
-}
-
-.stat-card.highlight .stat-hint {
-    color: rgba(255, 255, 255, 0.9);
+.stat-label svg {
+    color: var(--accent-soft);
 }
 
 .stat-value {
-    font-size: 1.5rem;
-    font-weight: 700;
+    font-size: clamp(26px, 3vw, 34px);
+    font-weight: 300;
+    letter-spacing: -0.01em;
+    line-height: 1.2;
+    color: var(--text-color);
 }
 
-/* Detail Stats */
-.detail-stats {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 1rem;
-    margin-bottom: 2rem;
+.stat-card.highlight {
+    background: linear-gradient(140deg, rgba(139, 92, 246, 0.85), rgba(91, 33, 182, 0.9));
+    border: 1px solid rgba(183, 157, 245, 0.4);
+    box-shadow: var(--glow-shadow-lg);
 }
 
-/* Section */
+.stat-card.highlight .stat-label,
+.stat-card.highlight .stat-content h3 {
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.stat-card.highlight .stat-label svg {
+    color: currentColor;
+}
+
+.stat-card.highlight .stat-value {
+    font-weight: 600;
+    color: #fff;
+}
+
+.stat-hint {
+    font-size: 12.5px;
+    color: var(--text-muted);
+    margin-top: 8px;
+}
+
+.stat-card.highlight .stat-hint {
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.stat-card-link {
+    color: inherit;
+    cursor: pointer;
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.stat-card-link:hover {
+    color: inherit;
+    transform: translateY(-2px);
+    box-shadow: 0 16px 52px rgba(109, 40, 217, 0.55);
+}
+
+/* ============================================================
+   Sections
+   ============================================================ */
 .section {
-    background-color: var(--card-bg);
-    border-radius: var(--radius);
-    padding: 1.5rem;
-    box-shadow: var(--shadow);
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: var(--radius-card);
+    padding: 24px 26px;
     margin-bottom: 1.5rem;
+}
+
+.section-plain {
+    background: none;
+    border: none;
+    border-radius: 0;
+    padding: 0;
 }
 
 .section-header {
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1rem;
+    gap: 14px 24px;
+    margin-bottom: 20px;
 }
 
-.section-header h2 {
-    font-size: 1.25rem;
+.section-header h2,
+.data-table-section h2,
+.yield-formula h2,
+.yield-result h2,
+.yield-details h2 {
+    font-size: clamp(20px, 2.6vw, 26px);
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    color: var(--text-color);
 }
 
-/* Tables */
+/* ============================================================
+   Investment row cards (dashboard)
+   ============================================================ */
+.investment-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.investment-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px 32px;
+    background: var(--row-bg);
+    border: 1px solid var(--row-border);
+    border-radius: var(--radius-row);
+    padding: 20px 24px;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.investment-row:hover {
+    background: var(--row-hover-bg);
+    border-color: var(--row-hover-border);
+}
+
+.inv-main {
+    flex: 1 1 260px;
+    min-width: 0;
+}
+
+.inv-name {
+    display: block;
+    font-size: 16px;
+    font-weight: 600;
+    color: #f0edf8;
+    line-height: 1.3;
+}
+
+.inv-name:hover {
+    color: var(--accent-text);
+}
+
+.inv-metrics {
+    flex: 2 1 330px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(105px, 1fr));
+    gap: 14px 24px;
+}
+
+.metric-label {
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    margin-bottom: 5px;
+}
+
+.metric-value {
+    font-size: 14.5px;
+    font-weight: 400;
+    color: var(--text-color);
+}
+
+.inv-actions {
+    flex: 0 0 auto;
+    display: flex;
+    gap: 8px;
+}
+
+/* Icon buttons */
+.icon-btn {
+    width: 38px;
+    height: 38px;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-soft);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.15s ease;
+}
+
+.icon-btn:hover {
+    background: rgba(255, 255, 255, 0.09);
+    color: var(--text-color);
+}
+
+.icon-btn-accent {
+    border-color: rgba(139, 92, 246, 0.4);
+    background: rgba(139, 92, 246, 0.14);
+    color: var(--accent-text);
+}
+
+.icon-btn-accent:hover {
+    background: rgba(139, 92, 246, 0.28);
+    color: var(--accent-text);
+}
+
+.icon-btn-danger {
+    border-color: var(--bad-border);
+    background: var(--bad-bg);
+    color: var(--bad);
+}
+
+.icon-btn-danger:hover {
+    background: rgba(244, 94, 94, 0.25);
+    color: var(--bad);
+}
+
+/* ============================================================
+   Tables
+   ============================================================ */
 .table-container {
     overflow-x: auto;
 }
@@ -318,182 +655,267 @@ main {
 
 .data-table th,
 .data-table td {
-    padding: 0.75rem 1rem;
+    padding: 0.85rem 1rem;
     text-align: left;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
 }
 
 .data-table th {
-    font-weight: 600;
-    color: var(--text-muted);
-    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--text-faint);
+    font-size: 11px;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.09em;
+}
+
+.data-table td {
+    font-size: 14.5px;
+}
+
+.data-table tbody tr {
+    transition: background-color 0.15s ease;
 }
 
 .data-table tbody tr:hover {
-    background-color: #f9fafb;
+    background-color: rgba(255, 255, 255, 0.03);
 }
 
 .data-table a {
-    color: var(--primary-color);
-    text-decoration: none;
-    font-weight: 500;
+    color: var(--text-color);
+    font-weight: 600;
 }
 
 .data-table a:hover {
-    text-decoration: underline;
+    color: var(--accent-text);
 }
 
-/* Buttons */
+.data-table tfoot {
+    font-weight: 600;
+}
+
+.data-table tfoot th {
+    padding: 0.85rem 1rem;
+    text-align: left;
+    color: var(--text-color);
+    font-size: 13px;
+    text-transform: none;
+    letter-spacing: 0;
+    border-bottom: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/* ============================================================
+   Buttons
+   ============================================================ */
 .btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.625rem 1.25rem;
-    border-radius: var(--radius);
-    font-weight: 500;
-    font-size: 0.875rem;
+    gap: 9px;
+    padding: 12px 22px;
+    border-radius: 999px;
+    font-family: inherit;
+    font-weight: 600;
+    font-size: 14.5px;
     text-decoration: none;
-    border: none;
+    border: 1px solid transparent;
     cursor: pointer;
     transition: all 0.2s;
+    line-height: 1.2;
 }
 
 .btn-primary {
-    background-color: var(--primary-color);
-    color: white;
+    background: linear-gradient(135deg, var(--accent), var(--accent-deep));
+    color: #fff;
+    box-shadow: var(--glow-shadow);
 }
 
 .btn-primary:hover {
-    background-color: var(--primary-hover);
+    color: #fff;
+    box-shadow: 0 8px 30px rgba(109, 40, 217, 0.6);
 }
 
 .btn-secondary {
-    background-color: var(--border-color);
-    color: var(--text-color);
+    background: var(--ctrl-bg);
+    border-color: var(--pill-border);
+    color: #cfcadd;
+    font-weight: 500;
 }
 
 .btn-secondary:hover {
-    background-color: #d1d5db;
+    background: rgba(255, 255, 255, 0.09);
+    color: var(--text-color);
 }
 
 .btn-success {
-    background-color: var(--success-color);
-    color: white;
+    background: var(--good-bg);
+    border-color: var(--good-border);
+    color: var(--good);
 }
 
 .btn-success:hover {
-    background-color: var(--success-hover);
+    background: rgba(52, 199, 123, 0.25);
+    color: var(--good);
 }
 
 .btn-danger {
-    background-color: var(--danger-color);
-    color: white;
+    background: var(--bad-bg);
+    border-color: var(--bad-border);
+    color: var(--bad);
 }
 
 .btn-danger:hover {
-    background-color: var(--danger-hover);
+    background: rgba(244, 94, 94, 0.25);
+    color: var(--bad);
 }
 
 .btn-info {
-    background-color: var(--info-color);
-    color: white;
+    background: var(--ctrl-bg);
+    border-color: var(--pill-border);
+    color: var(--text-soft);
+}
+
+.btn-info:hover {
+    background: rgba(255, 255, 255, 0.09);
+    color: var(--text-color);
+}
+
+.btn-warning {
+    background: var(--warn-bg);
+    border-color: var(--warn-border);
+    color: var(--warn);
+}
+
+.btn-warning:hover {
+    background: rgba(245, 185, 66, 0.25);
+    color: var(--warn);
 }
 
 .btn-sm {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.8rem;
+    padding: 8px 14px;
+    font-size: 13px;
+}
+
+.btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    box-shadow: none;
 }
 
 .action-buttons {
     display: flex;
-    gap: 0.5rem;
+    gap: 8px;
 }
 
-/* Badges */
+.actions-cell {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.inline-form {
+    display: inline;
+}
+
+/* ============================================================
+   Badges & chips
+   ============================================================ */
 .yield-badge {
     display: inline-block;
-    padding: 0.25rem 0.5rem;
-    border-radius: 9999px;
-    font-size: 0.75rem;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 12.5px;
     font-weight: 600;
+    border: 1px solid transparent;
 }
 
 .yield-dual {
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: 8px;
 }
 
 .yield-separator {
-    color: var(--text-muted);
+    color: #4d4960;
     font-weight: 400;
 }
 
 .yield-high {
-    background-color: #dcfce7;
-    color: #166534;
+    background-color: var(--good-bg);
+    border-color: var(--good-border);
+    color: var(--good);
 }
 
 .yield-medium {
-    background-color: #fef3c7;
-    color: #92400e;
+    background-color: var(--warn-bg);
+    border-color: var(--warn-border);
+    color: var(--warn);
 }
 
 .yield-low {
-    background-color: #fee2e2;
-    color: #991b1b;
+    background-color: var(--bad-bg);
+    border-color: var(--bad-border);
+    color: var(--bad);
 }
 
 .ticker-badge {
     display: inline-block;
-    padding: 0.25rem 0.75rem;
-    background-color: var(--bg-color);
-    border-radius: 9999px;
-    font-size: 0.875rem;
+    margin-top: 7px;
+    padding: 2px 10px;
+    background: rgba(139, 92, 246, 0.16);
+    border: 1px solid rgba(139, 92, 246, 0.3);
+    border-radius: 999px;
+    font-size: 11.5px;
     font-weight: 600;
-    color: var(--text-muted);
+    letter-spacing: 0.07em;
+    color: var(--accent-text);
 }
 
 .frequency-badge {
     display: inline-block;
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-    font-size: 0.75rem;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 12.5px;
     font-weight: 500;
+    border: 1px solid transparent;
 }
 
 .frequency-monthly {
-    background-color: #dbeafe;
-    color: #1e40af;
+    background-color: rgba(125, 208, 224, 0.13);
+    border-color: rgba(125, 208, 224, 0.35);
+    color: #8fd8e6;
 }
 
 .frequency-quarterly {
-    background-color: #f3e8ff;
-    color: #7c3aed;
+    background-color: rgba(139, 92, 246, 0.16);
+    border-color: rgba(139, 92, 246, 0.35);
+    color: var(--accent-text);
 }
 
 .frequency-yearly {
-    background-color: #fce7f3;
-    color: #be185d;
+    background-color: rgba(240, 121, 180, 0.13);
+    border-color: rgba(240, 121, 180, 0.35);
+    color: #f2a1c8;
 }
 
-/* Forms */
+/* ============================================================
+   Forms
+   ============================================================ */
 .form-page {
-    max-width: 600px;
+    max-width: 640px;
     margin: 0 auto;
 }
 
 .form-page h1 {
-    margin-bottom: 1.5rem;
+    margin-bottom: 24px;
 }
 
-.form-container {
-    background-color: var(--card-bg);
-    border-radius: var(--radius);
+.form-container,
+.card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: var(--radius-card);
     padding: 2rem;
-    box-shadow: var(--shadow);
 }
 
 .form-group {
@@ -503,33 +925,58 @@ main {
 .form-group label {
     display: block;
     font-weight: 500;
+    font-size: 13.5px;
+    color: var(--text-soft);
     margin-bottom: 0.5rem;
 }
 
 .form-group input,
 .form-group select,
-.form-group textarea {
+.form-group textarea,
+.form-control,
+.period-inputs select {
     width: 100%;
     padding: 0.75rem 1rem;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius);
-    font-size: 1rem;
-    transition: border-color 0.2s, box-shadow 0.2s;
+    background: var(--ctrl-bg);
+    border: 1px solid var(--ctrl-border);
+    border-radius: 14px;
+    color: var(--text-color);
+    font-family: inherit;
+    font-size: 14.5px;
+    transition: border-color 0.2s, box-shadow 0.2s, background-color 0.2s;
+}
+
+.form-group input::placeholder,
+.form-group textarea::placeholder {
+    color: var(--text-faint);
+}
+
+.form-group select,
+.period-inputs select {
+    appearance: none;
+    background-image: var(--chevron);
+    background-repeat: no-repeat;
+    background-position: right 14px center;
+    padding-right: 38px;
+    cursor: pointer;
 }
 
 .form-group input:focus,
 .form-group select:focus,
-.form-group textarea:focus {
+.form-group textarea:focus,
+.form-control:focus,
+.period-inputs select:focus {
     outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+    border-color: rgba(139, 92, 246, 0.65);
+    background: rgba(139, 92, 246, 0.07);
+    box-shadow: 0 0 0 3px rgba(139, 92, 246, 0.18);
 }
 
 .form-help {
     display: block;
-    font-size: 0.8rem;
+    font-size: 12.5px;
     color: var(--text-muted);
-    margin-top: 0.25rem;
+    margin-top: 0.4rem;
 }
 
 .period-inputs {
@@ -539,17 +986,6 @@ main {
 
 .period-inputs select {
     flex: 1;
-    padding: 0.75rem 1rem;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius);
-    font-size: 1rem;
-    transition: border-color 0.2s, box-shadow 0.2s;
-}
-
-.period-inputs select:focus {
-    outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
 }
 
 .form-actions {
@@ -559,7 +995,7 @@ main {
     margin-top: 2rem;
 }
 
-/* Radio Group */
+/* Radio group */
 .radio-group {
     display: flex;
     flex-direction: column;
@@ -571,15 +1007,16 @@ main {
     align-items: flex-start;
     gap: 0.75rem;
     padding: 1rem;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius);
+    background: var(--ctrl-bg);
+    border: 1px solid var(--ctrl-border);
+    border-radius: 14px;
     cursor: pointer;
     transition: all 0.2s;
 }
 
 .radio-option:hover {
-    border-color: var(--primary-color);
-    background-color: #f9fafb;
+    border-color: rgba(139, 92, 246, 0.5);
+    background: rgba(139, 92, 246, 0.08);
 }
 
 .radio-option input[type="radio"] {
@@ -588,7 +1025,7 @@ main {
 }
 
 .radio-option input[type="radio"]:checked + .radio-label strong {
-    color: var(--primary-color);
+    color: var(--accent-text);
 }
 
 .radio-label {
@@ -598,40 +1035,43 @@ main {
 
 .radio-label small {
     color: var(--text-muted);
-    font-size: 0.8rem;
+    font-size: 12.5px;
 }
 
-/* Yield Preview */
+/* Yield preview */
 .yield-preview {
-    background-color: #f0fdf4;
-    border: 1px solid #86efac;
-    border-radius: var(--radius);
+    background: var(--good-bg);
+    border: 1px solid var(--good-border);
+    border-radius: 14px;
     padding: 1rem;
     margin-top: 1.5rem;
 }
 
 .yield-preview h4 {
     margin-bottom: 0.5rem;
-    color: #166534;
+    color: var(--good);
 }
 
 .yield-preview p {
     margin: 0.25rem 0;
-    color: #166534;
+    color: var(--good);
 }
 
 .yield-preview span {
     font-weight: 600;
 }
 
-/* Chips */
+/* Chips (existing investments) */
 .existing-list {
     margin-top: 2rem;
 }
 
 .existing-list h3 {
     margin-bottom: 1rem;
-    font-size: 1rem;
+    font-size: 13px;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
     color: var(--text-muted);
 }
 
@@ -643,21 +1083,25 @@ main {
 
 .chip {
     padding: 0.5rem 1rem;
-    background-color: var(--bg-color);
-    border: 1px solid var(--border-color);
-    border-radius: 9999px;
-    font-size: 0.875rem;
+    background: var(--ctrl-bg);
+    border: 1px solid var(--pill-border);
+    border-radius: 999px;
+    color: var(--text-soft);
+    font-family: inherit;
+    font-size: 13.5px;
     cursor: pointer;
     transition: all 0.2s;
 }
 
 .chip:hover {
-    background-color: var(--primary-color);
-    color: white;
-    border-color: var(--primary-color);
+    background: rgba(139, 92, 246, 0.2);
+    color: var(--accent-text);
+    border-color: rgba(139, 92, 246, 0.45);
 }
 
-/* Empty State */
+/* ============================================================
+   Empty state
+   ============================================================ */
 .empty-state {
     text-align: center;
     padding: 3rem 1rem;
@@ -666,10 +1110,14 @@ main {
 .empty-icon {
     font-size: 3rem;
     margin-bottom: 1rem;
+    color: var(--accent-soft);
+    display: flex;
+    justify-content: center;
 }
 
 .empty-state h3 {
     margin-bottom: 0.5rem;
+    font-weight: 500;
     color: var(--text-color);
 }
 
@@ -678,7 +1126,9 @@ main {
     margin-bottom: 1.5rem;
 }
 
-/* Investment Detail */
+/* ============================================================
+   Investment detail
+   ============================================================ */
 .investment-detail h1 {
     display: inline;
 }
@@ -692,90 +1142,37 @@ main {
     gap: 1rem;
 }
 
+.detail-header .year-selector {
+    margin-bottom: 0;
+}
+
 .header-actions {
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
 }
 
-.inline-form {
-    display: inline;
-}
-
-.year-selector {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+.investment-detail .year-selector {
     margin-bottom: 1.5rem;
-    padding: 0.75rem 1rem;
-    background-color: var(--card-bg);
-    border-radius: var(--radius);
-    box-shadow: var(--shadow);
-    width: fit-content;
-}
-
-.year-selector label {
-    font-weight: 500;
-    color: var(--text-muted);
-}
-
-.year-selector select {
-    padding: 0.5rem 1rem;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius);
-    font-size: 1rem;
-    font-weight: 600;
-    background-color: var(--card-bg);
-    cursor: pointer;
-}
-
-.year-selector select:focus {
-    outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
-}
-
-.actions-cell {
-    display: flex;
-    gap: 0.25rem;
-    align-items: center;
 }
 
 .back-link {
-    margin-top: 1rem;
+    margin-top: 1.5rem;
 }
 
 .back-link a {
     color: var(--text-muted);
-    text-decoration: none;
 }
 
 .back-link a:hover {
-    color: var(--primary-color);
+    color: var(--accent-text);
 }
 
-/* Stat Card Link */
-.stat-card-link {
-    text-decoration: none;
-    color: inherit;
-    cursor: pointer;
-    transition: transform 0.2s, box-shadow 0.2s;
-}
-
-.stat-card-link:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-lg);
-}
-
-.stat-hint {
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    margin-top: 0.25rem;
-}
-
-/* Yield Breakdown Page */
+/* ============================================================
+   Yield breakdown
+   ============================================================ */
 .yield-breakdown {
-    padding: 2rem 0;
+    padding: 0;
 }
 
 .yield-header {
@@ -793,7 +1190,7 @@ main {
 
 .yield-subtitle {
     color: var(--text-muted);
-    font-size: 1.1rem;
+    font-size: 14.5px;
 }
 
 .yield-actions {
@@ -803,10 +1200,10 @@ main {
 
 .yield-summary-box {
     background: var(--card-bg);
-    border-radius: var(--radius);
+    border: 1px solid var(--card-border);
+    border-radius: var(--radius-card);
     padding: 2rem;
     margin-bottom: 2rem;
-    box-shadow: var(--shadow);
 }
 
 .yield-formula {
@@ -816,9 +1213,7 @@ main {
 .yield-formula h2,
 .yield-result h2,
 .yield-details h2 {
-    font-size: 1.25rem;
     margin-bottom: 1rem;
-    color: var(--text-color);
 }
 
 .formula-display {
@@ -826,10 +1221,11 @@ main {
     align-items: center;
     gap: 1rem;
     flex-wrap: wrap;
-    font-size: 1.1rem;
-    padding: 1rem;
-    background: var(--bg-color);
-    border-radius: var(--radius);
+    font-size: 1.05rem;
+    padding: 1.25rem;
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 14px;
 }
 
 .formula-fraction {
@@ -840,7 +1236,7 @@ main {
 }
 
 .formula-numerator {
-    border-bottom: 2px solid var(--text-color);
+    border-bottom: 2px solid var(--text-muted);
     padding-bottom: 0.25rem;
 }
 
@@ -850,13 +1246,15 @@ main {
 
 .formula-equals,
 .formula-multiply {
-    font-weight: bold;
+    font-weight: 600;
     font-size: 1.25rem;
+    color: var(--accent-text);
 }
 
 .result-calculation {
-    background: var(--bg-color);
-    border-radius: var(--radius);
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 14px;
     padding: 1.5rem;
 }
 
@@ -875,7 +1273,7 @@ main {
 }
 
 .calc-divider {
-    border-top: 2px solid var(--border-color);
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
     margin: 0.5rem 0;
 }
 
@@ -884,25 +1282,27 @@ main {
 }
 
 .calc-yield {
-    color: var(--success-color);
+    color: var(--good);
+    font-weight: 600;
 }
 
 .yield-details {
     background: var(--card-bg);
-    border-radius: var(--radius);
+    border: 1px solid var(--card-border);
+    border-radius: var(--radius-card);
     padding: 2rem;
-    box-shadow: var(--shadow);
     margin-bottom: 2rem;
 }
 
 .yield-note {
     color: var(--text-muted);
-    font-size: 0.9rem;
+    font-size: 13.5px;
     margin-bottom: 1.5rem;
     padding: 1rem;
-    background: var(--bg-color);
-    border-radius: var(--radius);
-    border-left: 4px solid var(--info-color);
+    background: rgba(139, 92, 246, 0.08);
+    border: 1px solid rgba(139, 92, 246, 0.2);
+    border-left: 4px solid var(--accent);
+    border-radius: 10px;
 }
 
 .yield-table {
@@ -912,17 +1312,18 @@ main {
 
 .yield-table th,
 .yield-table td {
-    padding: 0.75rem 1rem;
+    padding: 0.85rem 1rem;
     text-align: left;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
 }
 
 .yield-table th {
-    background: var(--bg-color);
-    font-weight: 600;
-    font-size: 0.875rem;
+    background: rgba(255, 255, 255, 0.03);
+    font-weight: 500;
+    font-size: 11px;
     text-transform: uppercase;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.09em;
+    color: var(--text-faint);
 }
 
 .yield-table .text-right {
@@ -930,7 +1331,7 @@ main {
 }
 
 .yield-table .totals-row {
-    background: var(--bg-color);
+    background: rgba(255, 255, 255, 0.03);
     font-weight: 600;
 }
 
@@ -941,39 +1342,634 @@ main {
 }
 
 .yield-total {
-    background: var(--primary-color) !important;
+    background: linear-gradient(135deg, var(--accent), var(--accent-deep)) !important;
     color: white !important;
+    border-radius: 8px;
 }
 
 .yield-footer {
     text-align: center;
     padding: 1rem;
     color: var(--text-muted);
-    font-size: 0.875rem;
+    font-size: 13px;
 }
 
 .print-date {
     margin-top: 1rem;
 }
 
-/* Footer */
+/* ============================================================
+   Dividend graph page
+   ============================================================ */
+.dividend-graph-page {
+    padding: 0;
+}
+
+.dividend-graph-page .page-header {
+    margin-bottom: 24px;
+}
+
+.graph-filters {
+    display: flex;
+    gap: 12px 20px;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.filter-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--ctrl-bg);
+    border: 1px solid var(--pill-border);
+    border-radius: 999px;
+    padding: 5px 8px 5px 18px;
+    font-size: 14px;
+}
+
+.filter-group label {
+    font-weight: 400;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+.filter-group select {
+    padding: 4px 30px 4px 8px;
+    border: none;
+    background: transparent;
+    color: var(--text-color);
+    font-family: inherit;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    max-width: 250px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    appearance: none;
+    background-image: var(--chevron);
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+}
+
+.filter-group select:focus {
+    outline: none;
+}
+
+.filter-group:has(.checkbox-label) {
+    padding: 9px 18px;
+}
+
+.graph-container {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: var(--radius-card);
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.chart-wrapper {
+    height: 400px;
+    margin-bottom: 1.5rem;
+}
+
+.chart-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.summary-card {
+    text-align: center;
+    padding: 1.25rem 1rem;
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 16px;
+}
+
+.summary-card h3 {
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 0.5rem;
+}
+
+.summary-value {
+    font-size: 1.35rem;
+    font-weight: 500;
+    color: var(--accent-text);
+}
+
+.data-table-section {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: var(--radius-card);
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.data-table-section h2 {
+    margin-bottom: 1rem;
+}
+
+/* ============================================================
+   Pagination
+   ============================================================ */
+.pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-top: 1.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.07);
+    flex-wrap: wrap;
+}
+
+.section-plain .pagination {
+    border-top: none;
+    padding-top: 0.5rem;
+}
+
+.pagination-info {
+    color: var(--text-muted);
+    font-size: 13px;
+    margin-right: 1rem;
+}
+
+.pagination-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 36px;
+    height: 36px;
+    padding: 0 0.75rem;
+    border-radius: 12px;
+    font-weight: 500;
+    font-size: 13.5px;
+    border: 1px solid var(--pill-border);
+    background: var(--ctrl-bg);
+    color: var(--text-soft);
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.pagination-btn:hover:not(.disabled):not(.active) {
+    border-color: rgba(139, 92, 246, 0.5);
+    color: var(--accent-text);
+    background: rgba(139, 92, 246, 0.12);
+}
+
+.pagination-btn.active {
+    background: linear-gradient(135deg, var(--accent), var(--accent-deep));
+    border-color: transparent;
+    color: white;
+    box-shadow: 0 4px 14px rgba(109, 40, 217, 0.4);
+}
+
+.pagination-btn.disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.pagination-ellipsis {
+    padding: 0 0.5rem;
+    color: var(--text-faint);
+}
+
+.items-per-page {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-left: 1rem;
+}
+
+.items-per-page label {
+    font-size: 13px;
+    color: var(--text-muted);
+}
+
+.items-per-page select {
+    padding: 0.375rem 1.9rem 0.375rem 0.75rem;
+    border: 1px solid var(--pill-border);
+    border-radius: 10px;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 500;
+    background: var(--ctrl-bg);
+    color: var(--text-color);
+    cursor: pointer;
+    appearance: none;
+    background-image: var(--chevron);
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+}
+
+/* ============================================================
+   Admin page
+   ============================================================ */
+.admin-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    margin-top: 1.5rem;
+    align-items: start;
+}
+
+.admin-card {
+    padding: 1.75rem;
+}
+
+.admin-card h2 {
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.9rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+    font-size: clamp(18px, 2vw, 22px);
+    font-weight: 500;
+    letter-spacing: -0.01em;
+}
+
+.admin-card h3 {
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 1rem;
+}
+
+.admin-form .form-section {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+.admin-form .form-section:last-of-type {
+    border-bottom: none;
+    margin-bottom: 1rem;
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1rem;
+}
+
+.preview-box {
+    background: rgba(52, 199, 123, 0.08);
+    border: 1px solid var(--good-border);
+    padding: 1rem;
+    border-radius: 14px;
+    margin-top: 1rem;
+    text-align: center;
+}
+
+.preview-label {
+    color: var(--text-muted);
+    font-size: 13px;
+    margin-right: 0.5rem;
+}
+
+.preview-value {
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: var(--good);
+}
+
+/* Database section */
+.db-info {
+    margin-bottom: 1.5rem;
+}
+
+.db-status {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    padding: 1rem;
+    border-radius: 14px;
+}
+
+.db-status-ok {
+    background: var(--good-bg);
+    border: 1px solid var(--good-border);
+}
+
+.db-status-warning {
+    background: var(--warn-bg);
+    border: 1px solid var(--warn-border);
+}
+
+.status-icon {
+    font-size: 1.5rem;
+    display: flex;
+    margin-top: 2px;
+}
+
+.db-status-ok .status-icon {
+    color: var(--good);
+}
+
+.db-status-warning .status-icon {
+    color: var(--warn);
+}
+
+.status-details strong {
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.db-status-ok .status-details strong {
+    color: var(--good);
+}
+
+.db-status-warning .status-details strong {
+    color: var(--warn);
+}
+
+.status-details p {
+    margin: 0.25rem 0;
+    font-size: 13px;
+    color: var(--text-muted);
+}
+
+.db-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.db-action-card {
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    padding: 1.25rem;
+    border-radius: 16px;
+}
+
+.db-action-card h3 {
+    color: var(--text-color);
+    text-transform: none;
+    letter-spacing: 0;
+    font-size: 15px;
+    margin-bottom: 0.5rem;
+}
+
+.db-action-card p {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin-bottom: 1rem;
+}
+
+.file-upload {
+    margin-bottom: 1rem;
+}
+
+.file-upload input[type="file"] {
+    display: none;
+}
+
+.file-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    background: var(--ctrl-bg);
+    border: 2px dashed var(--ctrl-border);
+    border-radius: 14px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.file-label:hover {
+    border-color: rgba(139, 92, 246, 0.55);
+    background: rgba(139, 92, 246, 0.08);
+}
+
+.file-icon {
+    font-size: 1.25rem;
+    display: flex;
+    color: var(--text-muted);
+}
+
+.file-text {
+    color: var(--text-muted);
+    font-size: 13.5px;
+}
+
+.file-name {
+    display: block;
+    margin-top: 0.5rem;
+    font-size: 13px;
+    color: var(--accent-text);
+    font-weight: 500;
+}
+
+.warning-box {
+    background: var(--warn-bg);
+    border: 1px solid var(--warn-border);
+    border-radius: 14px;
+    padding: 1rem;
+    font-size: 13.5px;
+    color: var(--text-soft);
+}
+
+.warning-box strong {
+    color: var(--warn);
+}
+
+/* ============================================================
+   Error pages
+   ============================================================ */
+.error-page {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 60vh;
+    padding: 2rem;
+}
+
+.error-container {
+    text-align: center;
+    max-width: 500px;
+}
+
+.error-icon {
+    font-size: 4rem;
+    margin-bottom: 1rem;
+}
+
+.error-code {
+    font-size: 6rem;
+    font-weight: 300;
+    letter-spacing: -0.03em;
+    background: linear-gradient(135deg, var(--accent-soft), var(--accent-deep));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    line-height: 1;
+    margin-bottom: 0.5rem;
+}
+
+.error-title {
+    font-size: 1.75rem;
+    font-weight: 500;
+    color: var(--text-color);
+    margin-bottom: 1rem;
+}
+
+.error-message {
+    font-size: 1rem;
+    color: var(--text-muted);
+    margin-bottom: 2rem;
+    line-height: 1.6;
+}
+
+.error-actions {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.error-suggestions {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    padding: 1.5rem;
+    text-align: left;
+}
+
+.error-suggestions h3,
+.error-suggestions h4 {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-color);
+    margin-bottom: 0.75rem;
+}
+
+.error-suggestions ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.error-suggestions li {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    padding: 0.35rem 0;
+    padding-left: 1.25rem;
+    position: relative;
+}
+
+.error-suggestions li::before {
+    content: "•";
+    position: absolute;
+    left: 0;
+    color: var(--accent-soft);
+}
+
+/* ============================================================
+   Modal
+   ============================================================ */
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(12, 10, 20, 0.7);
+    backdrop-filter: blur(4px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    padding: 1rem;
+}
+
+.modal-content {
+    background: #262234;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: var(--radius-card);
+    box-shadow: var(--shadow-lg);
+    max-width: 700px;
+    width: 100%;
+    max-height: 80vh;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.modal-header h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 500;
+    color: var(--text-color);
+}
+
+.modal-close {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    color: var(--text-muted);
+    padding: 0;
+    line-height: 1;
+    transition: color 0.2s;
+}
+
+.modal-close:hover {
+    color: var(--bad);
+}
+
+.modal-body {
+    padding: 1.5rem;
+    overflow-y: auto;
+}
+
+.modal-body .data-table {
+    margin: 0;
+}
+
+/* ============================================================
+   Footer
+   ============================================================ */
 .footer {
-    background-color: var(--card-bg);
     padding: 1.5rem 0;
     margin-top: auto;
-    border-top: 1px solid var(--border-color);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
 }
 
 .footer p {
     text-align: center;
-    color: var(--text-muted);
-    font-size: 0.875rem;
+    color: var(--text-faint);
+    font-size: 12.5px;
 }
 
-/* Print Styles */
+/* ============================================================
+   Print — force a light look on paper
+   ============================================================ */
 @media print {
+    :root {
+        color-scheme: light;
+    }
+
     body {
-        background: white;
+        background: white !important;
+        color: #1f2937 !important;
         font-size: 12pt;
     }
 
@@ -993,10 +1989,38 @@ main {
     }
 
     .yield-summary-box,
-    .yield-details {
-        box-shadow: none;
-        border: 1px solid #ddd;
+    .yield-details,
+    .section,
+    .stat-card {
+        background: white !important;
+        box-shadow: none !important;
+        border: 1px solid #ddd !important;
+        color: #1f2937 !important;
         break-inside: avoid;
+    }
+
+    .yield-title h1,
+    .yield-subtitle,
+    .yield-formula h2,
+    .yield-result h2,
+    .yield-details h2,
+    .calc-label,
+    .calc-value,
+    .yield-note,
+    .formula-equals,
+    .formula-multiply,
+    .yield-footer {
+        color: #1f2937 !important;
+    }
+
+    .formula-display,
+    .result-calculation {
+        background: #f3f4f6 !important;
+        border: 1px solid #ddd !important;
+    }
+
+    .formula-numerator {
+        border-bottom-color: #1f2937 !important;
     }
 
     .yield-table {
@@ -1006,12 +2030,18 @@ main {
     .yield-table th,
     .yield-table td {
         padding: 0.5rem;
+        color: #1f2937 !important;
+        border-bottom: 1px solid #ddd !important;
+    }
+
+    .yield-table th {
+        background: #f3f4f6 !important;
     }
 
     .yield-badge {
         border: 1px solid currentColor;
         background: transparent !important;
-        color: inherit !important;
+        color: #1f2937 !important;
         -webkit-print-color-adjust: exact;
         print-color-adjust: exact;
     }
@@ -1037,15 +2067,34 @@ main {
     }
 }
 
-/* Responsive */
+/* ============================================================
+   Responsive
+   ============================================================ */
+@media (max-width: 1024px) {
+    .admin-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 @media (max-width: 768px) {
-    .navbar .container {
-        flex-direction: column;
-        gap: 1rem;
+    .container {
+        padding: 0 16px;
     }
 
-    .nav-links {
-        gap: 1rem;
+    main {
+        padding: 28px 0 48px;
+    }
+
+    .navbar .container {
+        justify-content: center;
+    }
+
+    .nav-mask-toggle {
+        margin-left: 0;
+    }
+
+    .dashboard-header {
+        align-items: flex-start;
     }
 
     .detail-header {
@@ -1088,199 +2137,9 @@ main {
     .yield-table td {
         padding: 0.5rem;
     }
-}
 
-/* Admin Page Styles */
-.admin-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 2rem;
-    margin-top: 1.5rem;
-}
-
-.admin-card {
-    padding: 1.5rem;
-}
-
-.admin-card h2 {
-    margin-bottom: 1.5rem;
-    padding-bottom: 0.75rem;
-    border-bottom: 2px solid var(--border-color);
-    font-size: 1.25rem;
-}
-
-.admin-card h3 {
-    font-size: 1rem;
-    color: var(--text-muted);
-    margin-bottom: 1rem;
-}
-
-.admin-form .form-section {
-    margin-bottom: 2rem;
-    padding-bottom: 1.5rem;
-    border-bottom: 1px solid var(--border-color);
-}
-
-.admin-form .form-section:last-of-type {
-    border-bottom: none;
-    margin-bottom: 1rem;
-}
-
-.form-row {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 1rem;
-}
-
-.preview-box {
-    background-color: var(--bg-color);
-    padding: 1rem;
-    border-radius: var(--radius);
-    margin-top: 1rem;
-    text-align: center;
-}
-
-.preview-label {
-    color: var(--text-muted);
-    font-size: 0.875rem;
-    margin-right: 0.5rem;
-}
-
-.preview-value {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--success-color);
-}
-
-/* Database Section */
-.db-info {
-    margin-bottom: 1.5rem;
-}
-
-.db-status {
-    display: flex;
-    align-items: flex-start;
-    gap: 1rem;
-    padding: 1rem;
-    border-radius: var(--radius);
-}
-
-.db-status-ok {
-    background-color: rgba(22, 163, 74, 0.1);
-    border: 1px solid var(--success-color);
-}
-
-.db-status-warning {
-    background-color: rgba(245, 158, 11, 0.1);
-    border: 1px solid var(--warning-color);
-}
-
-.status-icon {
-    font-size: 1.5rem;
-}
-
-.status-details strong {
-    display: block;
-    margin-bottom: 0.5rem;
-}
-
-.status-details p {
-    margin: 0.25rem 0;
-    font-size: 0.875rem;
-    color: var(--text-muted);
-}
-
-.db-actions {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
-}
-
-.db-action-card {
-    background-color: var(--bg-color);
-    padding: 1.25rem;
-    border-radius: var(--radius);
-}
-
-.db-action-card h3 {
-    color: var(--text-color);
-    margin-bottom: 0.5rem;
-}
-
-.db-action-card p {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-    margin-bottom: 1rem;
-}
-
-.file-upload {
-    margin-bottom: 1rem;
-}
-
-.file-upload input[type="file"] {
-    display: none;
-}
-
-.file-label {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem;
-    background-color: var(--card-bg);
-    border: 2px dashed var(--border-color);
-    border-radius: var(--radius);
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.file-label:hover {
-    border-color: var(--primary-color);
-    background-color: rgba(37, 99, 235, 0.05);
-}
-
-.file-icon {
-    font-size: 1.25rem;
-}
-
-.file-text {
-    color: var(--text-muted);
-}
-
-.file-name {
-    display: block;
-    margin-top: 0.5rem;
-    font-size: 0.875rem;
-    color: var(--primary-color);
-    font-weight: 500;
-}
-
-.warning-box {
-    background-color: rgba(245, 158, 11, 0.1);
-    border: 1px solid var(--warning-color);
-    border-radius: var(--radius);
-    padding: 1rem;
-    font-size: 0.875rem;
-    color: var(--text-color);
-}
-
-.warning-box strong {
-    color: var(--warning-color);
-}
-
-.btn-warning {
-    background-color: var(--warning-color);
-    color: white;
-}
-
-.btn-warning:hover {
-    background-color: #d97706;
-}
-
-/* Admin page responsive */
-@media (max-width: 1024px) {
-    .admin-grid {
-        grid-template-columns: 1fr;
+    .investment-row {
+        padding: 18px 18px;
     }
 }
 
@@ -1292,228 +2151,15 @@ main {
     .form-row {
         grid-template-columns: 1fr;
     }
-}
 
-/* Dividend Graph Page */
-.dividend-graph-page {
-    padding: 1rem 0;
-}
-
-.dividend-graph-page .page-header {
-    margin-bottom: 1.5rem;
-}
-
-.dividend-graph-page .page-header h1 {
-    margin-bottom: 0.25rem;
-}
-
-.graph-filters {
-    display: flex;
-    gap: 1.5rem;
-    margin-bottom: 1.5rem;
-    flex-wrap: wrap;
-    padding: 1rem;
-    background-color: var(--card-bg);
-    border-radius: var(--radius);
-    box-shadow: var(--shadow);
-}
-
-.filter-group {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.filter-group label {
-    font-weight: 500;
-    color: var(--text-muted);
-}
-
-.filter-group select {
-    padding: 0.5rem 1rem;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius);
-    font-size: 1rem;
-    background-color: var(--card-bg);
-    cursor: pointer;
-    max-width: 250px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-}
-
-.filter-group select:focus {
-    outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
-}
-
-.graph-container {
-    background-color: var(--card-bg);
-    border-radius: var(--radius);
-    padding: 1.5rem;
-    box-shadow: var(--shadow);
-    margin-bottom: 1.5rem;
-}
-
-.chart-wrapper {
-    height: 400px;
-    margin-bottom: 1.5rem;
-}
-
-.chart-summary {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 1rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--border-color);
-}
-
-.summary-card {
-    text-align: center;
-    padding: 1rem;
-    background-color: var(--bg-color);
-    border-radius: var(--radius);
-}
-
-.summary-card h3 {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-    margin-bottom: 0.5rem;
-}
-
-.summary-value {
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--primary-color);
-}
-
-.data-table-section {
-    background-color: var(--card-bg);
-    border-radius: var(--radius);
-    padding: 1.5rem;
-    box-shadow: var(--shadow);
-    margin-bottom: 1.5rem;
-}
-
-.data-table-section h2 {
-    font-size: 1.25rem;
-    margin-bottom: 1rem;
-}
-
-.data-table tfoot {
-    font-weight: 600;
-    background-color: var(--bg-color);
-}
-
-.data-table tfoot th {
-    padding: 0.75rem 1rem;
-    text-align: left;
-}
-
-/* Pagination Styles */
-.pagination {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    margin-top: 1.5rem;
-    padding-top: 1rem;
-    border-top: 1px solid var(--border-color);
-}
-
-.pagination-info {
-    color: var(--text-muted);
-    font-size: 0.875rem;
-    margin-right: 1rem;
-}
-
-.pagination-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 36px;
-    height: 36px;
-    padding: 0 0.75rem;
-    border-radius: var(--radius);
-    font-weight: 500;
-    font-size: 0.875rem;
-    text-decoration: none;
-    border: 1px solid var(--border-color);
-    background-color: var(--card-bg);
-    color: var(--text-color);
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.pagination-btn:hover:not(.disabled):not(.active) {
-    border-color: var(--primary-color);
-    color: var(--primary-color);
-}
-
-.pagination-btn.active {
-    background-color: var(--primary-color);
-    border-color: var(--primary-color);
-    color: white;
-}
-
-.pagination-btn.disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-    pointer-events: none;
-}
-
-.pagination-ellipsis {
-    padding: 0 0.5rem;
-    color: var(--text-muted);
-}
-
-.items-per-page {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-left: 1rem;
-}
-
-.items-per-page label {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-}
-
-.items-per-page select {
-    padding: 0.375rem 0.75rem;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius);
-    font-size: 0.875rem;
-    background-color: var(--card-bg);
-    cursor: pointer;
-}
-
-/* Checkbox label in filters */
-.checkbox-label {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    cursor: pointer;
-    font-size: 0.875rem;
-    color: var(--text-color);
-}
-
-.checkbox-label input[type="checkbox"] {
-    width: 1rem;
-    height: 1rem;
-    cursor: pointer;
-    accent-color: var(--primary-color);
-}
-
-@media (max-width: 640px) {
     .graph-filters {
         flex-direction: column;
-        gap: 1rem;
+        align-items: stretch;
     }
 
     .filter-group {
         width: 100%;
+        justify-content: space-between;
     }
 
     .filter-group select {
@@ -1542,174 +2188,15 @@ main {
     .error-title {
         font-size: 1.5rem;
     }
-}
 
-/* Error Pages */
-.error-page {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 60vh;
-    padding: 2rem;
-}
-
-.error-container {
-    text-align: center;
-    max-width: 500px;
-}
-
-.error-icon {
-    font-size: 4rem;
-    margin-bottom: 1rem;
-}
-
-.error-code {
-    font-size: 6rem;
-    font-weight: 800;
-    color: var(--primary-color);
-    line-height: 1;
-    margin-bottom: 0.5rem;
-}
-
-.error-title {
-    font-size: 1.75rem;
-    font-weight: 600;
-    color: var(--text-color);
-    margin-bottom: 1rem;
-}
-
-.error-message {
-    font-size: 1.1rem;
-    color: var(--text-muted);
-    margin-bottom: 2rem;
-    line-height: 1.6;
-}
-
-.error-actions {
-    display: flex;
-    justify-content: center;
-    gap: 1rem;
-    margin-bottom: 2rem;
-}
-
-.error-suggestions {
-    background-color: var(--bg-color);
-    border-radius: var(--radius);
-    padding: 1.5rem;
-    text-align: left;
-}
-
-.error-suggestions h4 {
-    font-size: 0.95rem;
-    font-weight: 600;
-    color: var(--text-color);
-    margin-bottom: 0.75rem;
-}
-
-.error-suggestions ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.error-suggestions li {
-    font-size: 0.9rem;
-    color: var(--text-muted);
-    padding: 0.35rem 0;
-    padding-left: 1.25rem;
-    position: relative;
-}
-
-.error-suggestions li::before {
-    content: "•";
-    position: absolute;
-    left: 0;
-    color: var(--primary-color);
-}
-
-/* Modal Styles */
-.modal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1000;
-    padding: 1rem;
-}
-
-.modal-content {
-    background-color: var(--card-bg);
-    border-radius: var(--radius);
-    box-shadow: var(--shadow-lg);
-    max-width: 700px;
-    width: 100%;
-    max-height: 80vh;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-}
-
-.modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.5rem;
-    border-bottom: 1px solid var(--border-color);
-}
-
-.modal-header h3 {
-    margin: 0;
-    font-size: 1.25rem;
-    color: var(--text-color);
-}
-
-.modal-close {
-    background: none;
-    border: none;
-    font-size: 1.5rem;
-    cursor: pointer;
-    color: var(--text-muted);
-    padding: 0;
-    line-height: 1;
-    transition: color 0.2s;
-}
-
-.modal-close:hover {
-    color: var(--danger-color);
-}
-
-.modal-body {
-    padding: 1.5rem;
-    overflow-y: auto;
-}
-
-.modal-body .data-table {
-    margin: 0;
-}
-
-.modal-body .data-table a {
-    color: var(--primary-color);
-    text-decoration: none;
-}
-
-.modal-body .data-table a:hover {
-    text-decoration: underline;
-}
-
-@media (max-width: 640px) {
     .modal-content {
         max-height: 90vh;
     }
-    
+
     .modal-header {
         padding: 0.75rem 1rem;
     }
-    
+
     .modal-body {
         padding: 1rem;
     }

--- a/templates/add_dividend.html
+++ b/templates/add_dividend.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="form-page">
-    <h1>Record Dividend</h1>
+    <h1>Record <span>Dividend</span></h1>
     
     <div class="form-container">
         {% if investments %}
@@ -112,7 +112,7 @@
             </div>
 
             <div id="yield-preview" class="yield-preview hidden">
-                <h4>📊 Yield Preview</h4>
+                <h4>Yield Preview</h4>
                 <p>Annualized Dividend: <span id="annual-amount">{{ currency_symbol }}0.00</span></p>
                 <p>Estimated Yield: <span id="estimated-yield">0.00%</span></p>
             </div>
@@ -124,7 +124,9 @@
         </form>
         {% else %}
         <div class="empty-state">
-            <div class="empty-icon">📭</div>
+            <div class="empty-icon">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>
+            </div>
             <h3>No investments found</h3>
             <p>You need to add an investment before recording dividends.</p>
             <a href="{{ url_for('investments.add_investment') }}" class="btn btn-primary">Add Investment First</a>

--- a/templates/add_investment.html
+++ b/templates/add_investment.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="form-page">
-    <h1>Add Investment</h1>
+    <h1>Add <span>Investment</span></h1>
     
     <div class="form-container">
         <form method="post" action="{{ url_for('investments.add_investment') }}">

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -4,14 +4,14 @@
 
 {% block content %}
 <div class="page-header">
-    <h1>⚙️ Admin Settings</h1>
+    <h1>Admin <span>Settings</span></h1>
     <p class="text-muted">Manage application settings and database</p>
 </div>
 
 <div class="admin-grid">
     <!-- Settings Section -->
     <div class="card admin-card">
-        <h2>💱 Currency & Formatting</h2>
+        <h2>Currency & Formatting</h2>
         <form action="{{ url_for('admin.save_settings') }}" method="post" class="admin-form">
             <div class="form-section">
                 <h3>Currency</h3>
@@ -100,7 +100,7 @@
             </div>
 
             <div class="form-section">
-                <h3>📄 Pagination</h3>
+                <h3>Pagination</h3>
                 <div class="form-row">
                     <div class="form-group">
                         <label for="items_per_page">Items Per Page</label>
@@ -120,7 +120,7 @@
 
             <div class="form-actions">
                 <button type="submit" class="btn btn-primary">
-                    💾 Save Settings
+                    Save Settings
                 </button>
             </div>
         </form>
@@ -128,12 +128,14 @@
 
     <!-- Database Section -->
     <div class="card admin-card">
-        <h2>🗄️ Database Management</h2>
+        <h2>Database Management</h2>
         
         <div class="db-info">
             {% if db_exists %}
             <div class="db-status db-status-ok">
-                <span class="status-icon">✅</span>
+                <span class="status-icon">
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+                </span>
                 <div class="status-details">
                     <strong>Database Active</strong>
                     <p>File: dividends.db</p>
@@ -143,7 +145,9 @@
             </div>
             {% else %}
             <div class="db-status db-status-warning">
-                <span class="status-icon">⚠️</span>
+                <span class="status-icon">
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+                </span>
                 <div class="status-details">
                     <strong>No Database Found</strong>
                     <p>The database file does not exist yet.</p>
@@ -154,7 +158,7 @@
 
         <div class="db-actions">
             <div class="db-action-card">
-                <h3>📥 Download Backup</h3>
+                <h3>Download Backup</h3>
                 <p>Download a backup copy of your database file.</p>
                 {% if db_exists %}
                 <a href="{{ url_for('admin.download_db') }}" class="btn btn-primary">
@@ -166,27 +170,29 @@
             </div>
 
             <div class="db-action-card">
-                <h3>📤 Restore / Upload</h3>
+                <h3>Restore / Upload</h3>
                 <p>Upload a database file to replace the current one. A backup will be created automatically.</p>
                 <form action="{{ url_for('admin.upload_db') }}" method="post" enctype="multipart/form-data" 
                       onsubmit="return confirmUpload()">
                     <div class="file-upload">
                         <input type="file" id="db_file" name="db_file" accept=".db" required>
                         <label for="db_file" class="file-label">
-                            <span class="file-icon">📁</span>
+                            <span class="file-icon">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/></svg>
+                            </span>
                             <span class="file-text">Choose .db file</span>
                         </label>
                         <span id="file_name" class="file-name"></span>
                     </div>
                     <button type="submit" class="btn btn-warning">
-                        ⬆️ Upload & Replace
+                        Upload & Replace
                     </button>
                 </form>
             </div>
         </div>
 
         <div class="warning-box">
-            <strong>⚠️ Warning:</strong> Uploading a database will replace all current data. 
+            <strong>Warning:</strong> Uploading a database will replace all current data.
             Make sure to download a backup first. After uploading, restart the application for changes to take effect.
         </div>
     </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,24 +5,35 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="DiviTracker - Track and manage your dividend income from investments">
     <meta name="keywords" content="dividends, investments, portfolio, tracker, income">
+    <meta name="theme-color" content="#1c1928">
     <title>{% block title %}DiviTracker{% endblock title %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=mask2">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=night1">
 </head>
 <body>
+    {% set ep = request.endpoint or '' %}
     <nav class="navbar">
         <div class="container">
-            <a href="{{ url_for('main.index') }}" class="logo">💰 DiviTracker</a>
+            <a href="{{ url_for('main.index') }}" class="logo">
+                <span class="logo-mark">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><path d="M19 7V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/><path d="M21 12a1 1 0 0 0-1-1h-4a2 2 0 0 0 0 4h4a1 1 0 0 0 1-1v-2Z"/></svg>
+                </span>
+                DiviTracker
+            </a>
             <div class="nav-links">
-                <a href="{{ url_for('main.index') }}">Dashboard</a>
-                <a href="{{ url_for('main.dividend_graph') }}">📈 Graph</a>
-                <a href="{{ url_for('investments.add_investment') }}">Add Investment</a>
-                <a href="{{ url_for('dividends.add_dividend') }}">Add Dividend</a>
-                <a href="{{ url_for('admin.admin_index') }}">⚙️ Settings</a>
-                <button type="button" id="mask-toggle" class="nav-mask-toggle" onclick="toggleAmountsMask()" title="Hide/Show amounts" aria-pressed="false">
-                    <span class="mask-icon">👁️</span>
-                    <span class="mask-label">Hide amounts</span>
-                </button>
+                <a href="{{ url_for('main.index') }}" class="{{ 'active' if ep in ('main.index', 'main.yield_breakdown') or ep.startswith('investments.view') }}">Dashboard</a>
+                <a href="{{ url_for('main.dividend_graph') }}" class="{{ 'active' if ep == 'main.dividend_graph' }}">Graph</a>
+                <a href="{{ url_for('investments.add_investment') }}" class="{{ 'active' if ep == 'investments.add_investment' }}">Add investment</a>
+                <a href="{{ url_for('dividends.add_dividend') }}" class="{{ 'active' if ep == 'dividends.add_dividend' }}">Add dividend</a>
+                <a href="{{ url_for('admin.admin_index') }}" class="{{ 'active' if ep.startswith('admin.') }}">Settings</a>
             </div>
+            <button type="button" id="mask-toggle" class="nav-mask-toggle" onclick="toggleAmountsMask()" title="Hide/Show amounts" aria-pressed="false">
+                <svg class="icon-eye" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+                <svg class="icon-eye-off hidden" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"/><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"/><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"/><line x1="2" y1="2" x2="22" y2="22"/></svg>
+                <span class="mask-label">Hide amounts</span>
+            </button>
         </div>
     </nav>
 
@@ -61,14 +72,16 @@
             const STORAGE_KEY = 'divitracker.amountsMasked';
             const btn = document.getElementById('mask-toggle');
             const labelEl = btn ? btn.querySelector('.mask-label') : null;
-            const iconEl = btn ? btn.querySelector('.mask-icon') : null;
+            const eyeEl = btn ? btn.querySelector('.icon-eye') : null;
+            const eyeOffEl = btn ? btn.querySelector('.icon-eye-off') : null;
 
             function applyState(masked) {
                 document.body.classList.toggle('amounts-masked', masked);
                 if (btn) {
                     btn.setAttribute('aria-pressed', masked ? 'true' : 'false');
                     if (labelEl) labelEl.textContent = masked ? 'Show amounts' : 'Hide amounts';
-                    if (iconEl) iconEl.textContent = masked ? '🙈' : '👁️';
+                    if (eyeEl) eyeEl.classList.toggle('hidden', masked);
+                    if (eyeOffEl) eyeOffEl.classList.toggle('hidden', !masked);
                 }
             }
 

--- a/templates/dividend_graph.html
+++ b/templates/dividend_graph.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="dividend-graph-page">
     <div class="page-header">
-        <h1>📈 Dividend Graph</h1>
+        <h1>Dividend <span>Graph</span></h1>
         <p class="text-muted">Visual representation of your dividend income</p>
     </div>
 
@@ -154,11 +154,16 @@
     });
     
     const ctx = document.getElementById('dividendChart').getContext('2d');
-    
+
+    // Night theme chart defaults
+    Chart.defaults.color = '#948fa8';
+    Chart.defaults.borderColor = 'rgba(255, 255, 255, 0.07)';
+    Chart.defaults.font.family = "'Manrope', -apple-system, sans-serif";
+
     // Calculate gradient for bars
     const gradient = ctx.createLinearGradient(0, 0, 0, 400);
-    gradient.addColorStop(0, 'rgba(37, 99, 235, 0.8)');
-    gradient.addColorStop(1, 'rgba(37, 99, 235, 0.1)');
+    gradient.addColorStop(0, 'rgba(139, 92, 246, 0.85)');
+    gradient.addColorStop(1, 'rgba(139, 92, 246, 0.05)');
     
     const currencySymbol = '{{ settings.currency.symbol if settings else "₱" }}';
     
@@ -175,9 +180,9 @@
                     label: 'Dividend Amount',
                     data: values,
                     backgroundColor: gradient,
-                    borderColor: 'rgba(37, 99, 235, 1)',
+                    borderColor: 'rgba(167, 139, 250, 1)',
                     borderWidth: 1,
-                    borderRadius: 4,
+                    borderRadius: 6,
                     order: 2,
                     yAxisID: 'y',
                 },
@@ -185,11 +190,11 @@
                     label: 'Cumulative Total',
                     data: cumulativeValues,
                     type: 'line',
-                    borderColor: 'rgba(22, 163, 74, 1)',
-                    backgroundColor: 'rgba(22, 163, 74, 0.1)',
+                    borderColor: 'rgba(52, 199, 123, 1)',
+                    backgroundColor: 'rgba(52, 199, 123, 0.08)',
                     borderWidth: 2,
-                    pointBackgroundColor: 'rgba(22, 163, 74, 1)',
-                    pointBorderColor: '#fff',
+                    pointBackgroundColor: 'rgba(52, 199, 123, 1)',
+                    pointBorderColor: '#1c1928',
                     pointBorderWidth: 2,
                     pointRadius: 4,
                     pointHoverRadius: 6,

--- a/templates/edit_dividend.html
+++ b/templates/edit_dividend.html
@@ -4,8 +4,8 @@
 
 {% block content %}
 <div class="form-page">
-    <h1>Edit Dividend</h1>
-    <p class="subtitle">Update dividend record for {{ dividend.investment.name }}</p>
+    <h1>Edit <span>Dividend</span></h1>
+    <p class="page-subtitle" style="margin-bottom: 24px;">Update dividend record for {{ dividend.investment.name }}</p>
     
     <div class="form-container">
         <form method="post" action="{{ url_for('dividends.edit_dividend', dividend_id=dividend.id) }}">

--- a/templates/edit_investment.html
+++ b/templates/edit_investment.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="form-page">
-    <h1>Edit Investment</h1>
+    <h1>Edit <span>Investment</span></h1>
     
     <div class="form-container">
         <form method="post" action="{{ url_for('investments.edit_investment', investment_id=investment.id) }}">

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,11 +5,14 @@
 {% block content %}
 <div class="dashboard">
     <div class="dashboard-header">
-        <h1>Dividend Dashboard</h1>
+        <div>
+            <h1>Dividend <span>Dashboard</span></h1>
+            <p class="page-subtitle">Tracking {{ selected_year }} payouts across your portfolio</p>
+        </div>
         <div class="dashboard-filters">
             {% if years_with_dividends %}
             <div class="year-selector">
-                <label for="year-select">Year:</label>
+                <label for="year-select">Year</label>
                 <select id="year-select" onchange="updateFilters()">
                     {% for y in years_with_dividends %}
                     <option value="{{ y }}" {% if y == selected_year %}selected{% endif %}>{{ y }}</option>
@@ -25,7 +28,7 @@
             </div>
         </div>
     </div>
-    
+
     <script>
         function updateFilters() {
             const year = document.getElementById('year-select')?.value || {{ selected_year }};
@@ -33,7 +36,7 @@
             const perPage = document.getElementById('per-page-select')?.value || {{ items_per_page }};
             window.location.href = '/year/' + year + '?hide_zero=' + hideZero + '&per_page=' + perPage;
         }
-        
+
         function goToPage(page) {
             const year = document.getElementById('year-select')?.value || {{ selected_year }};
             const hideZero = document.getElementById('hide-zero').checked;
@@ -41,89 +44,89 @@
             window.location.href = '/year/' + year + '?hide_zero=' + hideZero + '&per_page=' + perPage + '&page=' + page;
         }
     </script>
-    
+
     <div class="stats-grid">
         <div class="stat-card">
-            <div class="stat-icon">📊</div>
-            <div class="stat-content">
-                <h3>Currently Invested</h3>
-                <p class="stat-value maskable">{{ format_currency(total_invested) }}</p>
+            <div class="stat-label">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/></svg>
+                Currently invested
             </div>
+            <p class="stat-value maskable">{{ format_currency(total_invested) }}</p>
         </div>
         <div class="stat-card">
-            <div class="stat-icon">💵</div>
-            <div class="stat-content">
-                <h3>Dividends Received ({{ selected_year }})</h3>
-                <p class="stat-value maskable">{{ format_currency(total_annual_dividends) }}</p>
+            <div class="stat-label">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="2" y="6" width="20" height="12" rx="2"/><circle cx="12" cy="12" r="2.5"/></svg>
+                Dividends received · {{ selected_year }}
             </div>
+            <p class="stat-value maskable">{{ format_currency(total_annual_dividends) }}</p>
         </div>
         <a href="{{ url_for('main.yield_breakdown', year=selected_year) }}" class="stat-card highlight stat-card-link">
-            <div class="stat-icon">📉</div>
-            <div class="stat-content">
-                <h3>Annualized Yield ({{ selected_year }})</h3>
-                <p class="stat-value">{{ "%.2f"|format(overall_yield) }}%</p>
-                <p class="stat-hint">Click for detailed computation</p>
+            <div class="stat-label">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/></svg>
+                Annualized yield · {{ selected_year }}
             </div>
+            <p class="stat-value">{{ "%.2f"|format(overall_yield) }}%</p>
+            <p class="stat-hint">Click for detailed computation →</p>
         </a>
     </div>
 
-    <div class="section">
+    <div class="section section-plain">
         <div class="section-header">
-            <h2>Your Investments</h2>
-            <a href="{{ url_for('investments.add_investment') }}" class="btn btn-primary">+ Add Investment</a>
+            <h2>Your investments</h2>
+            <a href="{{ url_for('investments.add_investment') }}" class="btn btn-primary">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                Add investment
+            </a>
         </div>
 
         {% if investments %}
-        <div class="table-container">
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Investment</th>
-                        <th>Ticker</th>
-                        <th>Invested</th>
-                        <th>Received ({{ selected_year }})</th>
-                        <th>Yield <small>(actual | projected)</small></th>
-                        <th>Actions</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for investment in investments %}
-                    <tr>
-                        <td>
-                            <a href="{{ url_for('investments.view_investment', investment_id=investment.id) }}">
-                                {{ investment.name }}
-                            </a>
-                        </td>
-                        <td>{{ investment.ticker or '-' }}</td>
-                        <td class="maskable">{{ format_currency(investment.total_invested) }}</td>
-                        <td class="maskable">{{ format_currency(investment.calculate_annual_dividends(selected_year)) }}</td>
-                        <td>
-                            <span class="yield-dual">
-                                <span class="yield-badge {% if investment.calculate_dividend_yield(selected_year) >= 5 %}yield-high{% elif investment.calculate_dividend_yield(selected_year) >= 2 %}yield-medium{% else %}yield-low{% endif %}">
-                                    {{ "%.2f"|format(investment.calculate_dividend_yield(selected_year)) }}%
-                                </span>
-                                <span class="yield-separator">|</span>
-                                <span class="yield-badge yield-projected {% if investment.calculate_dividend_yield(selected_year, projected=True) >= 5 %}yield-high{% elif investment.calculate_dividend_yield(selected_year, projected=True) >= 2 %}yield-medium{% else %}yield-low{% endif %}">
-                                    {{ "%.2f"|format(investment.calculate_dividend_yield(selected_year, projected=True)) }}%
-                                </span>
+        <div class="investment-list">
+            {% for investment in investments %}
+            <div class="investment-row">
+                <div class="inv-main">
+                    <a href="{{ url_for('investments.view_investment', investment_id=investment.id) }}" class="inv-name">{{ investment.name }}</a>
+                    {% if investment.ticker %}
+                    <span class="ticker-badge">{{ investment.ticker }}</span>
+                    {% endif %}
+                </div>
+                <div class="inv-metrics">
+                    <div class="metric">
+                        <div class="metric-label">Invested</div>
+                        <div class="metric-value maskable">{{ format_currency(investment.total_invested) }}</div>
+                    </div>
+                    <div class="metric">
+                        <div class="metric-label">Received {{ selected_year }}</div>
+                        <div class="metric-value maskable">{{ format_currency(investment.calculate_annual_dividends(selected_year)) }}</div>
+                    </div>
+                    <div class="metric">
+                        <div class="metric-label">Yield act | proj</div>
+                        <div class="metric-value yield-dual">
+                            <span class="yield-badge {% if investment.calculate_dividend_yield(selected_year) >= 5 %}yield-high{% elif investment.calculate_dividend_yield(selected_year) >= 2 %}yield-medium{% else %}yield-low{% endif %}">
+                                {{ "%.2f"|format(investment.calculate_dividend_yield(selected_year)) }}%
                             </span>
-                        </td>
-                        <td>
-                            <div class="action-buttons">
-                                <a href="{{ url_for('dividends.add_dividend', investment_id=investment.id) }}" class="btn btn-sm btn-success" title="Add Dividend">+💵</a>
-                                <a href="{{ url_for('investments.view_investment', investment_id=investment.id) }}" class="btn btn-sm btn-info" title="View Details">👁️</a>
-                            </div>
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                            <span class="yield-separator">|</span>
+                            <span class="yield-badge {% if investment.calculate_dividend_yield(selected_year, projected=True) >= 5 %}yield-high{% elif investment.calculate_dividend_yield(selected_year, projected=True) >= 2 %}yield-medium{% else %}yield-low{% endif %}">
+                                {{ "%.2f"|format(investment.calculate_dividend_yield(selected_year, projected=True)) }}%
+                            </span>
+                        </div>
+                    </div>
+                </div>
+                <div class="inv-actions">
+                    <a href="{{ url_for('dividends.add_dividend', investment_id=investment.id) }}" class="icon-btn icon-btn-accent" title="Add Dividend">
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                    </a>
+                    <a href="{{ url_for('investments.view_investment', investment_id=investment.id) }}" class="icon-btn" title="View Details">
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+                    </a>
+                </div>
+            </div>
+            {% endfor %}
         </div>
-        
+
         {% if total_pages > 1 or total_items > 5 %}
         <div class="pagination">
             <span class="pagination-info">Showing {{ ((page - 1) * items_per_page) + 1 }}-{{ [page * items_per_page, total_items] | min }} of {{ total_items }}</span>
-            
+
             {% if page > 1 %}
             <a href="#" onclick="goToPage(1); return false;" class="pagination-btn" title="First page">«</a>
             <a href="#" onclick="goToPage({{ page - 1 }}); return false;" class="pagination-btn" title="Previous page">‹</a>
@@ -131,7 +134,7 @@
             <span class="pagination-btn disabled">«</span>
             <span class="pagination-btn disabled">‹</span>
             {% endif %}
-            
+
             {% for p in range(1, total_pages + 1) %}
                 {% if p == page %}
                 <span class="pagination-btn active">{{ p }}</span>
@@ -141,7 +144,7 @@
                 <span class="pagination-ellipsis">...</span>
                 {% endif %}
             {% endfor %}
-            
+
             {% if page < total_pages %}
             <a href="#" onclick="goToPage({{ page + 1 }}); return false;" class="pagination-btn" title="Next page">›</a>
             <a href="#" onclick="goToPage({{ total_pages }}); return false;" class="pagination-btn" title="Last page">»</a>
@@ -149,7 +152,7 @@
             <span class="pagination-btn disabled">›</span>
             <span class="pagination-btn disabled">»</span>
             {% endif %}
-            
+
             <div class="items-per-page">
                 <label for="per-page-select">Per page:</label>
                 <select id="per-page-select" onchange="updateFilters()">
@@ -165,7 +168,9 @@
         {% endif %}
         {% else %}
         <div class="empty-state">
-            <div class="empty-icon">📭</div>
+            <div class="empty-icon">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>
+            </div>
             <h3>No investments yet</h3>
             <p>Start tracking your dividends by adding your first investment.</p>
             <a href="{{ url_for('investments.add_investment') }}" class="btn btn-primary">Add Your First Investment</a>

--- a/templates/view_investment.html
+++ b/templates/view_investment.html
@@ -12,7 +12,10 @@
             {% endif %}
         </div>
         <div class="header-actions">
-            <a href="{{ url_for('dividends.add_dividend', investment_id=investment.id) }}" class="btn btn-success">+ Add Dividend</a>
+            <a href="{{ url_for('dividends.add_dividend', investment_id=investment.id) }}" class="btn btn-success">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                Add Dividend
+            </a>
             <a href="{{ url_for('investments.edit_investment', investment_id=investment.id) }}" class="btn btn-secondary">Edit</a>
             <form method="post" action="{{ url_for('investments.delete_investment', investment_id=investment.id) }}" class="inline-form" onsubmit="return confirm('Are you sure you want to delete this investment and all its dividend records?');">
                 <button type="submit" class="btn btn-danger">Delete</button>
@@ -22,7 +25,7 @@
 
     {% if years_with_dividends %}
     <div class="year-selector">
-        <label for="year-select">View Year:</label>
+        <label for="year-select">Year</label>
         <select id="year-select" onchange="updatePageFilters()">
             {% for y in years_with_dividends %}
             <option value="{{ y }}" {% if y == selected_year %}selected{% endif %}>{{ y }}</option>
@@ -75,7 +78,10 @@
     <div class="section">
         <div class="section-header">
             <h2>Dividend History</h2>
-            <a href="{{ url_for('dividends.add_dividend', investment_id=investment.id) }}" class="btn btn-primary btn-sm">+ Add</a>
+            <a href="{{ url_for('dividends.add_dividend', investment_id=investment.id) }}" class="btn btn-primary btn-sm">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                Add
+            </a>
         </div>
 
         {% if dividends %}
@@ -106,9 +112,13 @@
                         <td>{{ "%.2f"|format(dividend.yield_at_time) ~ '%' if dividend.yield_at_time else '-' }}</td>
                         <td>{{ dividend.notes or '-' }}</td>
                         <td class="actions-cell">
-                            <a href="{{ url_for('dividends.edit_dividend', dividend_id=dividend.id) }}" class="btn btn-sm btn-secondary" title="Edit">✏️</a>
+                            <a href="{{ url_for('dividends.edit_dividend', dividend_id=dividend.id) }}" class="icon-btn" title="Edit">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
+                            </a>
                             <form method="post" action="{{ url_for('dividends.delete_dividend', dividend_id=dividend.id) }}" class="inline-form" onsubmit="return confirm('Delete this dividend record?');">
-                                <button type="submit" class="btn btn-sm btn-danger" title="Delete">🗑️</button>
+                                <button type="submit" class="icon-btn icon-btn-danger" title="Delete">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                                </button>
                             </form>
                         </td>
                     </tr>
@@ -162,7 +172,9 @@
         {% endif %}
         {% else %}
         <div class="empty-state">
-            <div class="empty-icon">📭</div>
+            <div class="empty-icon">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>
+            </div>
             <h3>No dividends recorded</h3>
             <p>Start tracking dividends for this investment.</p>
             <a href="{{ url_for('dividends.add_dividend', investment_id=investment.id) }}" class="btn btn-primary">Record First Dividend</a>

--- a/templates/yield_breakdown.html
+++ b/templates/yield_breakdown.html
@@ -6,11 +6,11 @@
 <div class="yield-breakdown">
     <div class="yield-header">
         <div class="yield-title">
-            <h1>Annualized Yield Calculation</h1>
+            <h1>Annualized <span>Yield</span></h1>
             <p class="yield-subtitle">Detailed breakdown for {{ selected_year }}</p>
         </div>
         <div class="yield-actions no-print">
-            <button onclick="window.print()" class="btn btn-primary">🖨️ Print</button>
+            <button onclick="window.print()" class="btn btn-primary">Print</button>
             <a href="{{ url_for('main.index', year=selected_year) }}" class="btn btn-secondary">← Back to Dashboard</a>
         </div>
     </div>
@@ -101,7 +101,9 @@
         </table>
         {% else %}
         <div class="empty-state">
-            <div class="empty-icon">📭</div>
+            <div class="empty-icon">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 16 12 14 15 10 15 8 12 2 12"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>
+            </div>
             <h3>No dividend data for {{ selected_year }}</h3>
             <p>Add dividends to see the yield calculation breakdown.</p>
         </div>

--- a/tests/features/web_routes.feature
+++ b/tests/features/web_routes.feature
@@ -44,7 +44,7 @@ Feature: Web Routes
     Scenario: Yield breakdown page loads
         When I visit "/reports/yield-breakdown"
         Then I should see status code 200
-        And I should see "Annualized Yield Calculation" in the page
+        And I should see "Yield Calculation Breakdown" in the page
 
     Scenario: Yield breakdown with year parameter
         When I visit "/reports/yield-breakdown?year=2025"
@@ -145,7 +145,7 @@ Feature: Web Routes
         Given an investment "Test Investment" with ticker "TEST" exists
         When I visit the edit page for investment "Test Investment"
         Then I should see status code 200
-        And I should see "Edit Investment" in the page
+        And I should see "Edit Test Investment" in the page
 
     Scenario: Edit investment via POST
         Given an investment "Test Investment" with ticker "TEST" and amount 10000 exists


### PR DESCRIPTION
## Summary

Restyles the entire app to the "DiviTracker Night" redesign look — a dark theme with a `#1c1928` background and purple radial glow, Manrope typography, glassy translucent cards, pill navigation, and purple gradient accents.

- **`static/style.css`** — full rewrite as a night design system (design tokens in `:root`, existing class names preserved so every page picks up the theme). Print styles force the yield report back to light so it stays readable on paper.
- **`base.html`** — Manrope font, gradient wallet logo mark, pill nav with active-page highlighting, Hide-amounts toggle rebuilt with eye/eye-off SVGs (same localStorage + blur mechanism as before)
- **`index.html`** — dashboard hero title, stat cards with stroke icons (annualized yield card gets the purple gradient + glow), and investments rendered as row cards with ticker chips, uppercase metric labels, colored yield chips, and icon action buttons (replaces the table)
- **`dividend_graph.html`** — Chart.js recolored for dark: purple gradient bars, green cumulative line, dark grid, Manrope labels
- **Remaining templates** — styled headings, dark form controls with custom chevron selects, and lucide-style SVG icons replacing emoji throughout

## Test plan

- [x] All 11 routes return 200 (dashboard, year filter, graph, yield breakdown, add/edit investment, add/edit dividend, settings, detail, 404 page)
- [x] Screenshot-verified every major page in headless Edge against the redesign mock
- [x] Print-to-PDF of the yield report renders light/readable
- [x] Amount masking toggle markup/JS wiring preserved (blur + hover reveal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)