### PR TITLE
Fix investment metric overflow on mobile

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2140,6 +2140,38 @@ main {
 
     .investment-row {
         padding: 18px 18px;
+        gap: 16px;
+    }
+
+    /* Stack metrics as label-left / value-right rows so the dual yield
+       badge no longer overflows the crushed 3-column grid on phones. */
+    .inv-metrics {
+        flex-basis: 100%;
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+
+    .metric {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 4px 16px;
+    }
+
+    .metric-label {
+        margin-bottom: 0;
+        white-space: nowrap;
+    }
+
+    /* margin-left:auto right-aligns the value, and flex-wrap lets it
+       drop below the label on very narrow screens instead of clipping. */
+    .metric-value {
+        margin-left: auto;
+        text-align: right;
+    }
+
+    .inv-actions {
+        flex-basis: 100%;
     }
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=night1">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v=night2">
 </head>
 <body>
     {% set ep = request.endpoint or '' %}


### PR DESCRIPTION
On phones the dashboard's investment cards crushed the three metric columns (invested / received / yield) into ~90px each, so the dual yield badge overflowed and clipped at the card's right edge.

Stack the metrics as single-column label-left / value-right rows on screens <=768px, with the value able to wrap below its label so it never clips even on very narrow (<=320px) devices. Bump the CSS cache-buster to night2.